### PR TITLE
rostime: Fixed a linking issue on OS X using boost 1.5+

### DIFF
--- a/rostime/CMakeLists.txt
+++ b/rostime/CMakeLists.txt
@@ -7,7 +7,7 @@ catkin_project(rostime
 include_directories(include ${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-find_package(Boost REQUIRED COMPONENTS date_time thread)
+find_package(Boost REQUIRED COMPONENTS date_time thread system)
 
 add_library(rostime 
   src/time.cpp src/rate.cpp src/duration.cpp)


### PR DESCRIPTION
See: http://answers.ros.org/question/43272/ros-install-problem-osx-1068/
