### PR TITLE
removed unused variable in serializedLength(const ArrayType& )

### DIFF
--- a/roscpp_serialization/include/ros/serialization.h
+++ b/roscpp_serialization/include/ros/serialization.h
@@ -609,7 +609,7 @@ struct ArraySerializer<T, N, typename boost::enable_if<mt::IsSimple<T> >::type>
     memcpy(&v.front(), stream.advance(data_len), data_len);
   }
 
-  inline static uint32_t serializedLength(const ArrayType& v)
+  inline static uint32_t serializedLength(const ArrayType& )
   {
     return N * sizeof(T);
   }


### PR DESCRIPTION
v caused a lot of confusing compilation warnings (especially eclipse's parser sees those as errors). I didn't want to remove the  argument completely to keep the interface.
