### PR TITLE
Promoting several core components which are communication library independent to the core

### DIFF
--- a/cpp_common/CMakeLists.txt
+++ b/cpp_common/CMakeLists.txt
@@ -29,6 +29,7 @@ if(HAVE_GLIBC_BACKTRACE)
 endif(HAVE_GLIBC_BACKTRACE)
 
 add_library(${PROJECT_NAME} src/debug.cpp src/header.cpp)
+target_link_libraries(${PROJECT_NAME} ${console_bridge_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}

--- a/cpp_common/CMakeLists.txt
+++ b/cpp_common/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cpp_common)
+find_package(console_bridge)
 find_package(catkin REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
@@ -9,7 +10,7 @@ include(CheckIncludeFile)
 include(CheckFunctionExists)
 include(CheckCXXSourceCompiles)
 
-include_directories(include)
+include_directories(include ${console_bridge_INCLUDE_DIRS})
 
 # execinfo.h is needed for backtrace on glibc systems
 CHECK_INCLUDE_FILE(execinfo.h HAVE_EXECINFO_H)
@@ -27,7 +28,7 @@ if(HAVE_GLIBC_BACKTRACE)
   add_definitions(-DHAVE_GLIBC_BACKTRACE)
 endif(HAVE_GLIBC_BACKTRACE)
 
-add_library(${PROJECT_NAME} src/debug.cpp)
+add_library(${PROJECT_NAME} src/debug.cpp src/header.cpp)
 
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}

--- a/cpp_common/include/ros/datatypes.h
+++ b/cpp_common/include/ros/datatypes.h
@@ -34,6 +34,9 @@
 #include <set>
 #include <list>
 
+#include <boost/shared_ptr.hpp>
+
+
 namespace ros {
 
 typedef std::vector<std::pair<std::string, std::string> > VP_string;
@@ -41,6 +44,8 @@ typedef std::vector<std::string> V_string;
 typedef std::set<std::string> S_string;
 typedef std::map<std::string, std::string> M_string;
 typedef std::pair<std::string, std::string> StringPair;
+
+typedef boost::shared_ptr<M_string> M_stringPtr;
 
 }
 

--- a/cpp_common/include/ros/datatypes.h
+++ b/cpp_common/include/ros/datatypes.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2008, Morgan Quigley and Willow Garage, Inc.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CPP_CORE_TYPES_H
+#define CPP_CORE_TYPES_H
+
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+#include <list>
+
+namespace ros {
+
+typedef std::vector<std::pair<std::string, std::string> > VP_string;
+typedef std::vector<std::string> V_string;
+typedef std::set<std::string> S_string;
+typedef std::map<std::string, std::string> M_string;
+typedef std::pair<std::string, std::string> StringPair;
+
+}
+
+#endif // CPP_CORE_TYPES_H

--- a/cpp_common/include/ros/header.h
+++ b/cpp_common/include/ros/header.h
@@ -1,0 +1,88 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CPP_CORE_HEADER_H
+#define CPP_CORE_HEADER_H
+
+#include <stdint.h>
+
+#include <boost/shared_array.hpp>
+
+#include "ros/datatypes.h"
+
+namespace ros
+{
+
+/**
+ * \brief Provides functionality to parse a connection header and retrieve values from it
+ */
+class Header
+{
+public:
+  Header();
+  ~Header();
+
+  /**
+   * \brief Get a value from a parsed header
+   * \param key Key value
+   * \param value OUT -- value corresponding to the key if there is one
+   * \return Returns true if the header had the specified key in it
+   */
+  bool getValue(const std::string& key, std::string& value) const;
+  /**
+   * \brief Returns a shared pointer to the internal map used
+   */
+  M_stringPtr getValues() { return read_map_; }
+
+  /**
+   * \brief Parse a header out of a buffer of data
+   */
+  bool parse(const boost::shared_array<uint8_t>& buffer, uint32_t size, std::string& error_msg);
+
+  /**
+   * \brief Parse a header out of a buffer of data
+   */
+  bool parse(uint8_t* buffer, uint32_t size, std::string& error_msg);
+
+  static void write(const M_string& key_vals, boost::shared_array<uint8_t>& buffer, uint32_t& size);
+
+private:
+
+  M_stringPtr read_map_;
+};
+
+}
+
+#endif // ROSCPP_HEADER_H

--- a/cpp_common/package.xml
+++ b/cpp_common/package.xml
@@ -15,5 +15,6 @@
   <url>http://www.ros.org/wiki/cpp_common</url>
   <author>John Faust</author>
 
+  <build_depend>console_bridge</build_depend>
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/cpp_common/src/header.cpp
+++ b/cpp_common/src/header.cpp
@@ -1,0 +1,170 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ros/header.h"
+
+#include "console_bridge/console.h"
+
+#include <sstream>
+
+#include <cstring>
+#include <cerrno>
+
+#define SROS_SERIALIZE_PRIMITIVE(ptr, data) { memcpy(ptr, &data, sizeof(data)); ptr += sizeof(data); }
+#define SROS_SERIALIZE_BUFFER(ptr, data, data_size) { if (data_size > 0) { memcpy(ptr, data, data_size); ptr += data_size; } }
+#define SROS_DESERIALIZE_PRIMITIVE(ptr, data) { memcpy(&data, ptr, sizeof(data)); ptr += sizeof(data); }
+#define SROS_DESERIALIZE_BUFFER(ptr, data, data_size) { if (data_size > 0) { memcpy(data, ptr, data_size); ptr += data_size; } }
+
+
+using namespace std;
+
+namespace ros
+{
+
+Header::Header()
+: read_map_(new M_string())
+{
+
+}
+
+Header::~Header()
+{
+
+}
+
+bool Header::parse(const boost::shared_array<uint8_t>& buffer, uint32_t size, std::string& error_msg)
+{
+  return parse(buffer.get(), size, error_msg);
+}
+
+bool Header::parse(uint8_t* buffer, uint32_t size, std::string& error_msg)
+{
+  uint8_t* buf = buffer;
+  while (buf < buffer + size)
+  {
+    uint32_t len;
+    SROS_DESERIALIZE_PRIMITIVE(buf, len);
+
+    if (len > 1000000)
+    {
+      error_msg = "Received an invalid TCPROS header.  Each element must be prepended by a 4-byte length.";
+      logError("%s", error_msg.c_str());
+
+      return false;
+    }
+
+    std::string line((char*)buf, len);
+
+    buf += len;
+
+    //printf(":%s:\n", line.c_str());
+    size_t eqpos = line.find_first_of("=", 0);
+    if (eqpos == string::npos)
+    {
+      error_msg = "Received an invalid TCPROS header.  Each line must have an equals sign.";
+      logError("%s", error_msg.c_str());
+
+      return false;
+    }
+    string key = line.substr(0, eqpos);
+    string value = line.substr(eqpos+1);
+
+    (*read_map_)[key] = value;
+  }
+
+  return true;
+}
+
+bool Header::getValue(const std::string& key, std::string& value) const
+{
+  M_string::const_iterator it = read_map_->find(key);
+  if (it == read_map_->end())
+  {
+    return false;
+  }
+
+  value = it->second;
+
+  return true;
+}
+
+void Header::write(const M_string& key_vals, boost::shared_array<uint8_t>& buffer, uint32_t& size)
+{
+  // Calculate the necessary size
+  size = 0;
+  {
+    M_string::const_iterator it = key_vals.begin();
+    M_string::const_iterator end = key_vals.end();
+    for (; it != end; ++it)
+    {
+      const std::string& key = it->first;
+      const std::string& value = it->second;
+
+      size += key.length();
+      size += value.length();
+      size += 1; // = sign
+      size += 4; // 4-byte length
+    }
+  }
+
+  if (size == 0)
+  {
+    return;
+  }
+
+  buffer.reset(new uint8_t[size]);
+  char* ptr = (char*)buffer.get();
+
+  // Write the data
+  {
+    M_string::const_iterator it = key_vals.begin();
+    M_string::const_iterator end = key_vals.end();
+    for (; it != end; ++it)
+    {
+      const std::string& key = it->first;
+      const std::string& value = it->second;
+
+      uint32_t len = key.length() + value.length() + 1;
+      SROS_SERIALIZE_PRIMITIVE(ptr, len);
+      SROS_SERIALIZE_BUFFER(ptr, key.data(), key.length());
+      static const char equals = '=';
+      SROS_SERIALIZE_PRIMITIVE(ptr, equals);
+      SROS_SERIALIZE_BUFFER(ptr, value.data(), value.length());
+    }
+  }
+
+  assert(ptr == (char*)buffer.get() + size);
+}
+
+}

--- a/roscpp_serialization/include/ros/serialization.h
+++ b/roscpp_serialization/include/ros/serialization.h
@@ -37,8 +37,10 @@
 #include "ros/message_traits.h"
 #include "ros/builtin_message_traits.h"
 #include "ros/exception.h"
+#include "ros/datatypes.h"
 
 #include <vector>
+#include <map>
 
 #include <boost/array.hpp>
 #include <boost/call_traits.hpp>
@@ -898,7 +900,48 @@ inline void deserializeMessage(const SerializedMessage& m, M& message)
   deserialize(s, message);
 }
 
+
+// Additional serialization traits
+
+template<typename M>
+struct PreDeserializeParams
+{
+  boost::shared_ptr<M> message;
+  boost::shared_ptr<std::map<std::string, std::string> > connection_header;
+};
+
+/**
+ * \brief called by the SubscriptionCallbackHelper after a message is
+ * instantiated but before that message is deserialized
+ */
+template<typename M>
+struct PreDeserialize
+{
+  static void notify(const PreDeserializeParams<M>&) { }
+};
+
 } // namespace serialization
+
+
+template<typename T>
+void
+assignSubscriptionConnectionHeader(T* t, const boost::shared_ptr<M_string>& connection_header,
+                                   typename boost::enable_if<ros::message_traits::IsMessage<T> >::type*_=0)
+{
+  (void)_; // warning stopper
+  t->__connection_header = connection_header;
+}
+
+template<typename T>
+void
+assignSubscriptionConnectionHeader(T* t, const boost::shared_ptr<M_string>& connection_header,
+                                   typename boost::disable_if<ros::message_traits::IsMessage<T> >::type*_=0)
+{ 
+  (void)_; // warning stopper
+}
+
+
+
 } // namespace ros
 
 #endif // ROSCPP_SERIALIZATION_H

--- a/roscpp_traits/CMakeLists.txt
+++ b/roscpp_traits/CMakeLists.txt
@@ -3,7 +3,7 @@ project(roscpp_traits)
 find_package(catkin REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS rostime)
+  CATKIN_DEPENDS cpp_common rostime)
 
 install(DIRECTORY include/
   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}

--- a/roscpp_traits/include/ros/message_event.h
+++ b/roscpp_traits/include/ros/message_event.h
@@ -1,0 +1,270 @@
+
+/*
+ * Copyright (C) 2010, Willow Garage, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSCPP_MESSAGE_EVENT_H
+#define ROSCPP_MESSAGE_EVENT_H
+
+#include "ros/time.h"
+#include <ros/message_traits.h>
+
+#include <boost/type_traits/is_void.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/add_const.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/function.hpp>
+#include <boost/make_shared.hpp>
+
+namespace ros
+{
+
+template<typename M>
+struct DefaultMessageCreator
+{
+  boost::shared_ptr<M> operator()()
+  {
+    return boost::make_shared<M>();
+  }
+};
+
+template<typename M>
+ROS_DEPRECATED inline boost::shared_ptr<M> defaultMessageCreateFunction()
+{
+  return DefaultMessageCreator<M>()();
+}
+
+/**
+ * \brief Event type for subscriptions, const ros::MessageEvent<M const>& can be used in your callback instead of const boost::shared_ptr<M const>&
+ *
+ * Useful if you need to retrieve meta-data about the message, such as the full connection header, or the publisher's node name
+ */
+template<typename M>
+class MessageEvent
+{
+public:
+  typedef typename boost::add_const<M>::type ConstMessage;
+  typedef typename boost::remove_const<M>::type Message;
+  typedef boost::shared_ptr<Message> MessagePtr;
+  typedef boost::shared_ptr<ConstMessage> ConstMessagePtr;
+  typedef boost::function<MessagePtr()> CreateFunction;
+
+  MessageEvent()
+  : nonconst_need_copy_(true)
+  {}
+
+  MessageEvent(const MessageEvent<Message>& rhs)
+  {
+    *this = rhs;
+  }
+
+  MessageEvent(const MessageEvent<ConstMessage>& rhs)
+  {
+    *this = rhs;
+  }
+
+  MessageEvent(const MessageEvent<Message>& rhs, bool nonconst_need_copy)
+  {
+    *this = rhs;
+    nonconst_need_copy_ = nonconst_need_copy;
+  }
+
+  MessageEvent(const MessageEvent<ConstMessage>& rhs, bool nonconst_need_copy)
+  {
+    *this = rhs;
+    nonconst_need_copy_ = nonconst_need_copy;
+  }
+
+  MessageEvent(const MessageEvent<void const>& rhs, const CreateFunction& create)
+  {
+    init(boost::const_pointer_cast<Message>(boost::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), create);
+  }
+
+  /**
+   * \todo Make this explicit in ROS 2.0.  Keep as auto-converting for now to maintain backwards compatibility in some places (message_filters)
+   */
+  MessageEvent(const ConstMessagePtr& message)
+  {
+    init(message, getConnectionHeader(message.get()), ros::Time::now(), true, ros::DefaultMessageCreator<Message>());
+  }
+
+  MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time)
+  {
+    init(message, connection_header, receipt_time, true, ros::DefaultMessageCreator<Message>());
+  }
+
+  MessageEvent(const ConstMessagePtr& message, ros::Time receipt_time)
+  {
+    init(message, getConnectionHeader(message.get()), receipt_time, true, ros::DefaultMessageCreator<Message>());
+  }
+
+  MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  {
+    init(message, connection_header, receipt_time, nonconst_need_copy, create);
+  }
+
+  void init(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
+  {
+    message_ = message;
+    connection_header_ = connection_header;
+    receipt_time_ = receipt_time;
+    nonconst_need_copy_ = nonconst_need_copy;
+    create_ = create;
+  }
+
+  void operator=(const MessageEvent<Message>& rhs)
+  {
+    init(boost::static_pointer_cast<Message>(rhs.getMessage()), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    message_copy_.reset();
+  }
+
+  void operator=(const MessageEvent<ConstMessage>& rhs)
+  {
+    init(boost::const_pointer_cast<Message>(boost::static_pointer_cast<ConstMessage>(rhs.getMessage())), rhs.getConnectionHeaderPtr(), rhs.getReceiptTime(), rhs.nonConstWillCopy(), rhs.getMessageFactory());
+    message_copy_.reset();
+  }
+
+  /**
+   * \brief Retrieve the message.  If M is const, this returns a reference to it.  If M is non const
+   * and this event requires it, returns a copy.  Note that it caches this copy for later use, so it will
+   * only every make the copy once
+   */
+  boost::shared_ptr<M> getMessage() const
+  {
+    return copyMessageIfNecessary<M>();
+  }
+
+  /**
+   * \brief Retrieve a const version of the message
+   */
+  const boost::shared_ptr<ConstMessage>& getConstMessage() const { return message_; }
+  /**
+   * \brief Retrieve the connection header
+   */
+  M_string& getConnectionHeader() const { return *connection_header_; }
+  const boost::shared_ptr<M_string>& getConnectionHeaderPtr() const { return connection_header_; }
+
+  /**
+   * \brief Returns the name of the node which published this message
+   */
+  const std::string& getPublisherName() const { return connection_header_ ? (*connection_header_)["callerid"] : s_unknown_publisher_string_; }
+
+  /**
+   * \brief Returns the time at which this message was received
+   */
+  ros::Time getReceiptTime() const { return receipt_time_; }
+
+  bool nonConstWillCopy() const { return nonconst_need_copy_; }
+  bool getMessageWillCopy() const { return !boost::is_const<M>::value && nonconst_need_copy_; }
+
+  bool operator<(const MessageEvent<M>& rhs)
+  {
+    if (message_ != rhs.message_)
+    {
+      return message_ < rhs.message_;
+    }
+
+    if (receipt_time_ != rhs.receipt_time_)
+    {
+      return receipt_time_ < rhs.receipt_time_;
+    }
+
+    return nonconst_need_copy_ < rhs.nonconst_need_copy_;
+  }
+
+  bool operator==(const MessageEvent<M>& rhs)
+  {
+    return message_ = rhs.message_ && receipt_time_ == rhs.receipt_time_ && nonconst_need_copy_ == rhs.nonconst_need_copy_;
+  }
+
+  bool operator!=(const MessageEvent<M>& rhs)
+  {
+    return !(*this == rhs);
+  }
+
+  const CreateFunction& getMessageFactory() const { return create_; }
+
+private:
+  template<typename M2>
+  typename boost::disable_if<boost::is_void<M2>, boost::shared_ptr<M> >::type copyMessageIfNecessary() const
+  {
+    if (boost::is_const<M>::value || !nonconst_need_copy_)
+    {
+      return boost::const_pointer_cast<Message>(message_);
+    }
+
+    if (message_copy_)
+    {
+      return message_copy_;
+    }
+
+    assert(create_);
+    message_copy_ = create_();
+    *message_copy_ = *message_;
+
+    return message_copy_;
+  }
+
+  template<typename M2>
+  typename boost::enable_if<boost::is_void<M2>, boost::shared_ptr<M> >::type copyMessageIfNecessary() const
+  {
+    return boost::const_pointer_cast<Message>(message_);
+  }
+
+  template<typename T>
+  boost::shared_ptr<ros::M_string>
+  getConnectionHeader(T* t, typename boost::enable_if<ros::message_traits::IsMessage<T> >::type*_ = 0) const
+  {
+    return t->__connection_header;
+  }
+
+  template<typename T>
+  boost::shared_ptr<ros::M_string>
+  getConnectionHeader(T* t, typename boost::disable_if<ros::message_traits::IsMessage<T> >::type*_ = 0) const
+  {
+    return boost::shared_ptr<ros::M_string>();
+  }
+
+
+  ConstMessagePtr message_;
+  // Kind of ugly to make this mutable, but it means we can pass a const MessageEvent to a callback and not worry about other things being modified
+  mutable MessagePtr message_copy_;
+  boost::shared_ptr<M_string> connection_header_;
+  ros::Time receipt_time_;
+  bool nonconst_need_copy_;
+  CreateFunction create_;
+
+  static const std::string s_unknown_publisher_string_;
+};
+
+template<typename M> const std::string MessageEvent<M>::s_unknown_publisher_string_("unknown_publisher");
+
+
+}
+
+#endif // ROSCPP_MESSAGE_EVENT_H

--- a/roscpp_traits/include/ros/message_event.h
+++ b/roscpp_traits/include/ros/message_event.h
@@ -30,6 +30,7 @@
 #define ROSCPP_MESSAGE_EVENT_H
 
 #include "ros/time.h"
+#include <ros/datatypes.h>
 #include <ros/message_traits.h>
 
 #include <boost/type_traits/is_void.hpp>

--- a/roscpp_traits/package.xml
+++ b/roscpp_traits/package.xml
@@ -15,5 +15,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>cpp_common</run_depend>
   <run_depend>rostime</run_depend>
 </package>


### PR DESCRIPTION
This allows for the usage of these elements w/o a dependency on ros_comm.  Related pull request coming in ros_comm.  

This also switches to use console_bridge instead of rosconsole. 
