### PR TITLE
OSX compile fix

### DIFF
--- a/roscpp_traits/include/ros/message_forward.h
+++ b/roscpp_traits/include/ros/message_forward.h
@@ -28,11 +28,6 @@
 #ifndef ROSLIB_MESSAGE_FORWARD_H
 #define ROSLIB_MESSAGE_FORWARD_H
 
-namespace std
-{
-template<typename T> class allocator;
-}
-
 namespace boost
 {
 template<typename T> class shared_ptr;


### PR DESCRIPTION
I am not sure why this is in message_forward.h, but when compiling on OSX 10.9 with libc++ this causes an error when compiling with generated messages.

Not sure this is the proper fix, but it worked for me.
