### PR TITLE
Support for older visual studio versions

### DIFF
--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -50,8 +50,23 @@
 #include <math.h>
 #include <stdexcept>
 #include <climits>
-#include <stdint.h>
 #include "rostime_decl.h"
+
+// this is just for interoperability with visual studio, where the standard
+// integer types are not defined.
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600 ) // MS express/studio 2008 or earlier
+  typedef          __int64  int64_t;
+  typedef unsigned __int64 uint64_t;
+  typedef          __int32  int32_t;
+  typedef unsigned __int32 uint32_t;
+  typedef          __int16  int16_t;
+  typedef unsigned __int16 uint16_t;
+  typedef          __int8    int8_t;
+  typedef unsigned __int8   uint8_t;
+#else
+  #include <stdint.h>
+#endif
 
 namespace boost {
   namespace posix_time {


### PR DESCRIPTION
changed '#include <stdint.h>' based on
roscpp_core/cpp_common/include/ros/types.h to support older versions of
visual studio
