### PR TITLE
Add a run_depend on console_bridge

### DIFF
--- a/cpp_common/CMakeLists.txt
+++ b/cpp_common/CMakeLists.txt
@@ -3,6 +3,7 @@ project(cpp_common)
 find_package(console_bridge)
 find_package(catkin REQUIRED)
 catkin_package(
+  DEPENDS console_bridge
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME})
 

--- a/cpp_common/package.xml
+++ b/cpp_common/package.xml
@@ -16,5 +16,6 @@
   <author>John Faust</author>
 
   <build_depend>console_bridge</build_depend>
+  <run_depend>console_bridge</run_depend>
   <buildtool_depend>catkin</buildtool_depend>
 </package>


### PR DESCRIPTION
Packages that build against cpp_common need console_bridge installed so that they can link against it.
