### PR TITLE
Remove assignment of __connection_header field in roscpp_core

### DIFF
--- a/roscpp_serialization/include/ros/serialization.h
+++ b/roscpp_serialization/include/ros/serialization.h
@@ -923,24 +923,6 @@ struct PreDeserialize
 } // namespace serialization
 
 
-template<typename T>
-void
-assignSubscriptionConnectionHeader(T* t, const boost::shared_ptr<M_string>& connection_header,
-                                   typename boost::enable_if<ros::message_traits::IsMessage<T> >::type*_=0)
-{
-  (void)_; // warning stopper
-  t->__connection_header = connection_header;
-}
-
-template<typename T>
-void
-assignSubscriptionConnectionHeader(T* t, const boost::shared_ptr<M_string>& connection_header,
-                                   typename boost::disable_if<ros::message_traits::IsMessage<T> >::type*_=0)
-{ 
-  (void)_; // warning stopper
-}
-
-
 
 } // namespace ros
 

--- a/roscpp_traits/include/ros/message_event.h
+++ b/roscpp_traits/include/ros/message_event.h
@@ -111,7 +111,7 @@ public:
    */
   MessageEvent(const ConstMessagePtr& message)
   {
-    init(message, getConnectionHeader(message.get()), ros::Time::now(), true, ros::DefaultMessageCreator<Message>());
+    init(message, boost::shared_ptr<M_string>(), ros::Time::now(), true, ros::DefaultMessageCreator<Message>());
   }
 
   MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time)
@@ -121,7 +121,7 @@ public:
 
   MessageEvent(const ConstMessagePtr& message, ros::Time receipt_time)
   {
-    init(message, getConnectionHeader(message.get()), receipt_time, true, ros::DefaultMessageCreator<Message>());
+    init(message, boost::shared_ptr<M_string>(), receipt_time, true, ros::DefaultMessageCreator<Message>());
   }
 
   MessageEvent(const ConstMessagePtr& message, const boost::shared_ptr<M_string>& connection_header, ros::Time receipt_time, bool nonconst_need_copy, const CreateFunction& create)
@@ -236,21 +236,6 @@ private:
   {
     return boost::const_pointer_cast<Message>(message_);
   }
-
-  template<typename T>
-  boost::shared_ptr<ros::M_string>
-  getConnectionHeader(T* t, typename boost::enable_if<ros::message_traits::IsMessage<T> >::type*_ = 0) const
-  {
-    return t->__connection_header;
-  }
-
-  template<typename T>
-  boost::shared_ptr<ros::M_string>
-  getConnectionHeader(T* t, typename boost::disable_if<ros::message_traits::IsMessage<T> >::type*_ = 0) const
-  {
-    return boost::shared_ptr<ros::M_string>();
-  }
-
 
   ConstMessagePtr message_;
   // Kind of ugly to make this mutable, but it means we can pass a const MessageEvent to a callback and not worry about other things being modified


### PR DESCRIPTION
__connection_header field will go away in Indigo
