### PR TITLE
Additional fix for compile issue on OS X 10.10

### DIFF
--- a/roscpp_traits/include/ros/message_forward.h
+++ b/roscpp_traits/include/ros/message_forward.h
@@ -28,6 +28,9 @@
 #ifndef ROSLIB_MESSAGE_FORWARD_H
 #define ROSLIB_MESSAGE_FORWARD_H
 
+// Make sure that either __GLIBCXX__ or _LIBCPP_VERSION is defined.
+#include <cstddef>
+
 // C++ standard section 17.4.3.1/1 states that forward declarations of STL types
 // that aren't specializations involving user defined types results in undefined
 // behavior. Apparently only libc++ has a problem with this and won't compile it.


### PR DESCRIPTION
When building ROS on Mac OS X (yosemite), rosbag_storage and roscpp have compile errors (`error: no type named 'allocator' in namespace 'std'`).  The fix in issue #15 is extended to handle the packages which don't include any file which would cause either `__GLIBCXX__` or `_LIBCPP_VERSION` to be defined.

See: http://stackoverflow.com/a/25892335
