### PR TITLE
fix WallRate constructor

### DIFF
--- a/rostime/src/rate.cpp
+++ b/rostime/src/rate.cpp
@@ -107,7 +107,7 @@ WallRate::WallRate(double frequency)
 
 WallRate::WallRate(const Duration& d)
 : start_(WallTime::now())
-, expected_cycle_time_(1.0 / d.toSec())
+, expected_cycle_time_(d.sec, d.nsec)
 , actual_cycle_time_(0.0)
 {}
 

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -440,6 +440,13 @@ TEST(Rate, constructFromDuration){
   EXPECT_EQ(r.expectedCycleTime(), d);
 }
 
+TEST(WallRate, constructFromDuration){
+  Duration d(4, 0);
+  WallRate r(d);
+  WallDuration wd(4, 0);
+  EXPECT_EQ(r.expectedCycleTime(), wd);
+}
+
 ///////////////////////////////////////////////////////////////////////////////////
 // WallTime/WallDuration
 ///////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix #38.

The same problem / fix as for `Rate` some time ago (#26).
