### PR TITLE
fixed serializer bool on ARM

### DIFF
--- a/roscpp_serialization/include/ros/serialization.h
+++ b/roscpp_serialization/include/ros/serialization.h
@@ -243,7 +243,7 @@ template<> struct Serializer<bool>
   {
     uint8_t b = (uint8_t)v;
 #if defined(__arm__) || defined(__arm)
-    memcpy(stream.advance(sizeof(1)), &b, 1 );
+    memcpy(stream.advance(1), &b, 1 );
 #else
     *reinterpret_cast<uint8_t*>(stream.advance(1)) = b;
 #endif
@@ -253,7 +253,7 @@ template<> struct Serializer<bool>
   {
     uint8_t b;
 #if defined(__arm__) || defined(__arm)
-    memcpy(&b, stream.advance(sizeof(1)), 1 );
+    memcpy(&b, stream.advance(1), 1 );
 #else
     b = *reinterpret_cast<uint8_t*>(stream.advance(1));
 #endif


### PR DESCRIPTION
Fixes #42.

Without the fix message serialization still works since it just happens to write three extra bytes which it shouldn't. The boolean value is correctly represented in the byte stream. But with a known allocated storage it might write over the expected limit.

The problem especially happens when using a serializer instance with a custom buffer which doesn't have the three extra byte at the end as in the reference ticket.
