### PR TITLE
change semantic of Duration::sleep return value

### DIFF
--- a/rostime/CMakeLists.txt
+++ b/rostime/CMakeLists.txt
@@ -32,6 +32,10 @@ install(DIRECTORY include/
   FILES_MATCHING PATTERN "*.h")
 
 if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(${PROJECT_NAME}-test_duration test/duration.cpp)
+  if(TARGET ${PROJECT_NAME}-test_duration)
+    target_link_libraries(${PROJECT_NAME}-test_duration ${catkin_LIBRARIES} rostime)
+  endif()
   catkin_add_gtest(${PROJECT_NAME}-test_time test/time.cpp)
   if(TARGET ${PROJECT_NAME}-test_time)
     target_link_libraries(${PROJECT_NAME}-test_time ${catkin_LIBRARIES} rostime)

--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -120,6 +120,7 @@ public:
   explicit Duration(const Rate&);
   /**
    * \brief sleep for the amount of time specified by this Duration.  If a signal interrupts the sleep, resleeps for the time remaining.
+   * @return True if the desired sleep duration was met, false otherwise.
    */
   bool sleep() const;
 };
@@ -147,6 +148,7 @@ public:
   explicit WallDuration(const Rate&);
   /**
    * \brief sleep for the amount of time specified by this Duration.  If a signal interrupts the sleep, resleeps for the time remaining.
+   * @return True if the desired sleep duration was met, false otherwise.
    */
   bool sleep() const;
 };

--- a/rostime/include/ros/rate.h
+++ b/rostime/include/ros/rate.h
@@ -101,7 +101,7 @@ public:
 
   /**
    * @brief  Sleeps for any leftover time in a cycle. Calculated from the last time sleep, reset, or the constructor was called.
-   * @return Passes through the return value from WallDuration::sleep() if it slept, otherwise True
+   * @return Passes through the return value from WallDuration::sleep() if it slept, false otherwise.
    */
   bool sleep();
 

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -186,6 +186,7 @@ namespace ros
     static Time now();
     /**
      * \brief Sleep until a specific time has been reached.
+     * @return True if the desired sleep time was met, false otherwise.
      */
     static bool sleepUntil(const Time& end);
 
@@ -241,6 +242,7 @@ namespace ros
 
     /**
      * \brief Sleep until a specific time has been reached.
+     * @return True if the desired sleep time was met, false otherwise.
      */
     static bool sleepUntil(const WallTime& end);
 

--- a/rostime/src/rate.cpp
+++ b/rostime/src/rate.cpp
@@ -142,7 +142,7 @@ bool WallRate::sleep()
     {
       start_ = actual_end;
     }
-    return true;
+    return false;
   }
 
   return sleep_time.sleep();

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -404,9 +404,11 @@ namespace ros
             end = TIME_MAX;
           }
 
+        bool rc = false;
         while (!g_stopped && (Time::now() < end))
           {
             ros_wallsleep(0, 1000000);
+            rc = true;
 
             // If we started at time 0 wait for the first actual time to arrive before starting the timer on
             // our sleep
@@ -423,7 +425,7 @@ namespace ros
               }
           }
 
-        return true;
+        return rc && !g_stopped;
       }
   }
 

--- a/rostime/test/duration.cpp
+++ b/rostime/test/duration.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, Open Source Robotics Foundation, Inc..
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <ros/duration.h>
+#include <ros/time.h>
+
+using namespace ros;
+
+TEST(Duration, sleepWithSimTime)
+{
+  ros::Time::init();
+
+  Time start = Time::now();
+  start -= Duration(2.0);
+  Time::setNow(start);
+
+  Time::shutdown();
+
+  Duration d(1.0);
+  bool rc = d.sleep();
+  ASSERT_FALSE(rc);
+}
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -428,10 +428,11 @@ TEST(Duration, sleepWithSignal)
   alarm(1);
   Time start = Time::now();
   Duration d(2.0);
-  d.sleep();
+  bool rc = d.sleep();
   Time end = Time::now();
 
   ASSERT_GT(end - start, d);
+  ASSERT_TRUE(rc);
 }
 
 TEST(Rate, constructFromDuration){


### PR DESCRIPTION
This implements the semantic change of the return value of `Duration::sleep` as mentioned in #39. This is to align the behavior with `Rate::sleep` and allows to distinguish if the desired sleep duration was met or not.
