### PR TITLE
Removed warning unused parameter

### DIFF
--- a/roscpp_serialization/include/ros/serialization.h
+++ b/roscpp_serialization/include/ros/serialization.h
@@ -204,7 +204,7 @@ inline uint32_t serializationLength(const T& t)
       memcpy(&v, stream.advance(sizeof(v)), sizeof(v) ); \
     } \
     \
-    inline static uint32_t serializedLength(const Type t) \
+    inline static uint32_t serializedLength(const Type&) \
       { \
       return sizeof(Type); \
     } \


### PR DESCRIPTION
There is a warning about the variable 't' not being used for ARM builds. I haven't tested this changeset.
