### PR TITLE
changes between 0.5.7 and 0.6.2 for backporting

### DIFF
--- a/rostime/CMakeLists.txt
+++ b/rostime/CMakeLists.txt
@@ -34,6 +34,7 @@ install(DIRECTORY include/
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(${PROJECT_NAME}-test_time test/time.cpp)
   if(TARGET ${PROJECT_NAME}-test_time)
+    set_property(TARGET ${PROJECT_NAME}-test_time APPEND_STRING PROPERTY COMPILE_FLAGS "-std=c++11")
     target_link_libraries(${PROJECT_NAME}-test_time ${catkin_LIBRARIES} rostime)
   endif()
 endif()

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -154,7 +154,7 @@ namespace ros
       sec = (uint32_t)floor(t);
       nsec = (uint32_t)boost::math::round((t-sec) * 1e9);
       // avoid rounding errors
-      sec += (nsec % 1000000000ul);
+      sec += (nsec / 1000000000ul);
       nsec %= 1000000000ul;
       return *static_cast<T*>(this);
     }

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -150,7 +150,14 @@ namespace ros
     bool operator<=(const T &rhs) const;
 
     double toSec()  const { return (double)sec + 1e-9*(double)nsec; };
-    T& fromSec(double t) { sec = (uint32_t)floor(t); nsec = (uint32_t)boost::math::round((t-sec) * 1e9);  return *static_cast<T*>(this);}
+    T& fromSec(double t) {
+      sec = (uint32_t)floor(t);
+      nsec = (uint32_t)boost::math::round((t-sec) * 1e9);
+      // avoid rounding errors
+      sec += (nsec % 1000000000ul);
+      nsec %= 1000000000ul;
+      return *static_cast<T*>(this);
+    }
 
     uint64_t toNSec() const {return (uint64_t)sec*1000000000ull + (uint64_t)nsec;  }
     T& fromNSec(uint64_t t);

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -152,6 +152,21 @@ TEST(Time, ToFromDouble)
 
 }
 
+TEST(Time, RoundingError)
+{
+  double someInt = 1031.0; // some integer
+  double t = std::nextafter(someInt, 0); // someint - epsilon
+  // t should be 1031.000000
+
+  ros::Time exampleTime;
+  exampleTime.fromSec(t);
+
+  // if rounded incorrectly, sec may be 1030
+  // and nsec may be 1e9.
+  EXPECT_EQ(exampleTime.sec, 1031);
+  EXPECT_EQ(exampleTime.nsec, 0);
+}
+
 TEST(Time, OperatorPlus)
 {
   Time t(100, 0);


### PR DESCRIPTION
The following list of changes has been integrated into roscpp_core 0.6.2 (Lunar / Kinetic) since the last Jade / Indigo release (0.5.7).

**Backported:** (these changes are part of this PR)

* fix rounding error in TimeBase #49, #50
  * fix bug

**Not backported:**

* change semantic of duration sleep #47
  * change of sematic, high chance of breaking compatibility
* fix compiler warnings #51, #52, #53
  * changes to comply with Kinetic buildfarm, no need to backport

@ros/ros_team Please comment on the decision which changes to (not) backport.