### PR TITLE
define macro with API call rather than relying on short macro being d…

### DIFF
--- a/cpp_common/src/header.cpp
+++ b/cpp_common/src/header.cpp
@@ -49,7 +49,8 @@
 // Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
 // in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
 #ifndef CONSOLE_BRIDGE_logError
-  #define CONSOLE_BRIDGE_logError logError
+# define CONSOLE_BRIDGE_logError(fmt, ...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
 #endif
 
 using namespace std;


### PR DESCRIPTION
…efined

Similar to https://github.com/ros/ros_comm/pull/1235 and https://github.com/ros/class_loader/pull/66