### PR TITLE
expose ros_walltime and ros_steadytime

### DIFF
--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -115,6 +115,8 @@ namespace ros
   ROSTIME_DECL void normalizeSecNSec(uint64_t& sec, uint64_t& nsec);
   ROSTIME_DECL void normalizeSecNSec(uint32_t& sec, uint32_t& nsec);
   ROSTIME_DECL void normalizeSecNSecUnsigned(int64_t& sec, int64_t& nsec);
+  ROSTIME_DECL void ros_walltime(uint32_t& sec, uint32_t& nsec);
+  ROSTIME_DECL void ros_steadytime(uint32_t& sec, uint32_t& nsec);
 
   /*********************************************************************
    ** Time Classes

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -95,11 +95,7 @@ namespace ros
   /*********************************************************************
    ** Cross Platform Functions
    *********************************************************************/
-  /*
-   * These have only internal linkage to this translation unit.
-   * (i.e. not exposed to users of the time classes)
-   */
-  void ros_walltime(uint32_t& sec, uint32_t& nsec) 
+  void ros_walltime(uint32_t& sec, uint32_t& nsec)
   {
 #ifndef WIN32
 #if HAS_CLOCK_GETTIME
@@ -220,6 +216,11 @@ namespace ros
     nsec = steady_nsec;
 #endif
   }
+
+  /*
+   * These have only internal linkage to this translation unit.
+   * (i.e. not exposed to users of the time classes)
+   */
 
   /**
    * @brief Simple representation of the rt library nanosleep function.


### PR DESCRIPTION
so we can use these cross platform implementations elsewhere.
See e.g. https://github.com/ros/ros_comm/pull/1249