### PR TITLE
Argument to boost microseconds must be integral in Boost >= 1.67

### DIFF
--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -179,7 +179,7 @@ namespace ros {
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return bt::seconds(sec) + bt::nanoseconds(nsec);
 #else
-    return bt::seconds(sec) + bt::microseconds(nsec/1000.0);
+    return bt::seconds(sec) + bt::microseconds(nsec/1000);
 #endif
   }
 }

--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -167,7 +167,7 @@ namespace ros
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return pt::from_time_t(sec) + pt::nanoseconds(nsec);
 #else
-    return pt::from_time_t(sec) + pt::microseconds(nsec/1000.0);
+    return pt::from_time_t(sec) + pt::microseconds(nsec/1000);
 #endif
   }
 


### PR DESCRIPTION
With Boost >= 1.67 compilation of roscpp_core fails because boost now requires the
`microseconds` constructor argument to be integral.

The `git diff boost-1.66.0 include/boost/date_time/time_duration.hpp` in boost date_time git repository confirms that the constructor to `boost::date_time::subsecond_duration` was made more stringent:
```diff
@@ -278,14 +280,15 @@ namespace date_time {
     BOOST_STATIC_CONSTANT(boost::int64_t, adjustment_ratio = (traits_type::ticks_per_second >= frac_of_second ? traits_type::ticks_per_second / frac_of_second : frac_of_second / traits_type::ticks_per_second));
 
   public:
-    explicit subsecond_duration(boost::int64_t ss) :
+    // The argument (ss) must be an integral type
+    template <typename T>
+    explicit subsecond_duration(T const& ss,
+                                typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
       base_duration(impl_type(traits_type::ticks_per_second >= frac_of_second ? ss * adjustment_ratio : ss / adjustment_ratio))
     {
     }
   };
```
The patch here simply makes it an integer, which should not make any difference, if I'm correct?