### PR TITLE
rostime: removed empty destructor of TimeBase (which makes TimeBase, …

### DIFF
--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -138,7 +138,6 @@ namespace ros
       normalizeSecNSec(sec, nsec);
     }
     explicit TimeBase(double t) { fromSec(t); }
-    ~TimeBase() {}
     D operator-(const T &rhs) const;
     T operator+(const D &rhs) const;
     T operator-(const D &rhs) const;


### PR DESCRIPTION
…Time and WallTime trivially copyable).

This enables the use of these types in contexts where trivial copyability is required, for instance `std::atomic` or components where `memcpy` is used.