### PR TITLE
Argument to Boost microseconds must be integral in Boost >= 1.67

### DIFF
--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -179,7 +179,7 @@ namespace ros {
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return bt::seconds(sec) + bt::nanoseconds(nsec);
 #else
-    return bt::seconds(sec) + bt::microseconds(nsec/1000.0);
+    return bt::seconds(sec) + bt::microseconds(nsec/1000);
 #endif
   }
 }

--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -167,7 +167,7 @@ namespace ros
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return pt::from_time_t(sec) + pt::nanoseconds(nsec);
 #else
-    return pt::from_time_t(sec) + pt::microseconds(nsec/1000.0);
+    return pt::from_time_t(sec) + pt::microseconds(nsec/1000);
 #endif
   }
 


### PR DESCRIPTION
Addresses https://github.com/ros/roscpp_core/issues/84 by changing float to integer division in the transformation from nano to microseconds.