### PR TITLE
Fix for Duration::fromSec() which had rounding issues

### DIFF
--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -51,13 +51,13 @@ namespace ros {
   }
 
   template<class T>
-  T& DurationBase<T>::fromSec(double t)
+  T& DurationBase<T>::fromSec(double d)
   {
-    int64_t sec64 = (int64_t)floor(t);
+    int64_t sec64 = (int64_t)floor(d);
     if (sec64 < INT_MIN || sec64 > INT_MAX)
       throw std::runtime_error("Duration is out of dual 32-bit range");
     sec = (int32_t)sec64;
-    nsec = (int32_t)boost::math::round((t-sec) * 1e9);
+    nsec = (int32_t)boost::math::round((d - sec) * 1e9);
     int32_t rollover = nsec / 1000000000ul;
     sec += rollover;
     nsec %= 1000000000ul;

--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -37,6 +37,7 @@
 #include <ros/duration.h>
 #include <ros/rate.h>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/math/special_functions/round.hpp>
 
 namespace ros {
   //
@@ -50,13 +51,16 @@ namespace ros {
   }
 
   template<class T>
-  T& DurationBase<T>::fromSec(double d)
+  T& DurationBase<T>::fromSec(double t)
   {
-    int64_t sec64 = (int64_t)floor(d);
+    int64_t sec64 = (int64_t)floor(t);
     if (sec64 < INT_MIN || sec64 > INT_MAX)
       throw std::runtime_error("Duration is out of dual 32-bit range");
     sec = (int32_t)sec64;
-    nsec = (int32_t)(nearbyint((d - (double)sec)*1000000000));
+    nsec = (int32_t)boost::math::round((t-sec) * 1e9);
+    int32_t rollover = nsec / 1000000000ul;
+    sec += rollover;
+    nsec %= 1000000000ul;
     return *static_cast<T*>(this);
   }
 

--- a/rostime/test/duration.cpp
+++ b/rostime/test/duration.cpp
@@ -128,6 +128,33 @@ TEST(Duration, negativeSignExceptions)
     EXPECT_EQ(2147483647999999998, d7.toNSec());
 }
 
+TEST(Duration, rounding)
+{
+    ros::Time::init();
+
+    Duration d1(49.999999999);
+    EXPECT_EQ(49, d1.sec);
+    EXPECT_EQ(999999999, d1.nsec);
+    Duration d2(-49.999999999);
+    EXPECT_EQ(-50, d2.sec);
+    EXPECT_EQ(1, d2.nsec);
+
+    Duration d3(49.9999999996);
+    EXPECT_EQ(50, d3.sec);
+    EXPECT_EQ(0, d3.nsec);
+    Duration d4(-49.9999999996);
+    EXPECT_EQ(-50, d4.sec);
+    EXPECT_EQ(0, d4.nsec);
+
+    Duration d5(49.9999999995);
+    EXPECT_EQ(49, d5.sec);
+    EXPECT_EQ(999999999, d5.nsec);
+    Duration d6(-49.9999999995);
+    EXPECT_EQ(-50, d6.sec);
+    EXPECT_EQ(1, d6.nsec);
+    
+}
+
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/rostime/test/duration.cpp
+++ b/rostime/test/duration.cpp
@@ -132,27 +132,33 @@ TEST(Duration, rounding)
 {
     ros::Time::init();
 
-    Duration d1(49.999999999);
+    Duration d1(49.0000000004);
     EXPECT_EQ(49, d1.sec);
-    EXPECT_EQ(999999999, d1.nsec);
-    Duration d2(-49.999999999);
-    EXPECT_EQ(-50, d2.sec);
-    EXPECT_EQ(1, d2.nsec);
+    EXPECT_EQ(0, d1.nsec);
+    Duration d2(-49.0000000004);
+    EXPECT_EQ(-49, d2.sec);
+    EXPECT_EQ(0, d2.nsec);
 
-    Duration d3(49.9999999996);
-    EXPECT_EQ(50, d3.sec);
-    EXPECT_EQ(0, d3.nsec);
-    Duration d4(-49.9999999996);
+    Duration d3(49.0000000006);
+    EXPECT_EQ(49, d3.sec);
+    EXPECT_EQ(1, d3.nsec);
+    Duration d4(-49.0000000006);
     EXPECT_EQ(-50, d4.sec);
-    EXPECT_EQ(0, d4.nsec);
-
-    Duration d5(49.9999999995);
+    EXPECT_EQ(999999999, d4.nsec);
+    
+    Duration d5(49.9999999994);
     EXPECT_EQ(49, d5.sec);
     EXPECT_EQ(999999999, d5.nsec);
-    Duration d6(-49.9999999995);
+    Duration d6(-49.9999999994);
     EXPECT_EQ(-50, d6.sec);
     EXPECT_EQ(1, d6.nsec);
     
+    Duration d7(49.9999999996);
+    EXPECT_EQ(50, d7.sec);
+    EXPECT_EQ(0, d7.nsec);
+    Duration d8(-49.9999999996);
+    EXPECT_EQ(-50, d8.sec);
+    EXPECT_EQ(0, d8.nsec);
 }
 
 int main(int argc, char **argv){

--- a/rostime/test/duration.cpp
+++ b/rostime/test/duration.cpp
@@ -145,14 +145,14 @@ TEST(Duration, rounding)
     Duration d4(-49.0000000006);
     EXPECT_EQ(-50, d4.sec);
     EXPECT_EQ(999999999, d4.nsec);
-    
+
     Duration d5(49.9999999994);
     EXPECT_EQ(49, d5.sec);
     EXPECT_EQ(999999999, d5.nsec);
     Duration d6(-49.9999999994);
     EXPECT_EQ(-50, d6.sec);
     EXPECT_EQ(1, d6.nsec);
-    
+
     Duration d7(49.9999999996);
     EXPECT_EQ(50, d7.sec);
     EXPECT_EQ(0, d7.nsec);


### PR DESCRIPTION
Fix Duration::fromSec() call to 1) handle the case where nanoseconds were rounding to another second and 2) handle negative durations properly.

See https://github.com/ros/roscpp_core/issues/92