### PR TITLE
update the use of macros in platform.h

### DIFF
--- a/cpp_common/include/ros/platform.h
+++ b/cpp_common/include/ros/platform.h
@@ -31,35 +31,10 @@
 #define CPP_COMMON_PLATFORM_H_
 
 /******************************************************************************
-* Includes
-******************************************************************************/
-
-#ifdef WIN32
-  #ifdef _MSC_VER
-    #ifndef WIN32_LEAN_AND_MEAN
-      #define WIN32_LEAN_AND_MEAN // slimmer compile times
-    #endif
-
-    #ifndef _WINSOCKAPI_
-      #define _WINSOCKAPI_ // stops windows.h from including winsock.h (and lets us include winsock2.h)
-    #endif
-
-    #ifndef NOMINMAX
-      #define NOMINMAX // windows c++ pollutes the environment like any factory
-    #endif
-  #endif
-  #include <windows.h>
-#endif
-
-
-
-/******************************************************************************
 * Cross Platform Functions
 ******************************************************************************/
 
-#ifndef _MSC_VER
-  #include <stdlib.h> // getenv
-#endif
+#include <stdlib.h> // getenv, _dupenv_s
 #include <string>
 
 namespace ros {

--- a/cpp_common/include/ros/platform.h
+++ b/cpp_common/include/ros/platform.h
@@ -36,9 +36,17 @@
 
 #ifdef WIN32
   #ifdef _MSC_VER
-    #define WIN32_LEAN_AND_MEAN // slimmer compile times
-    #define _WINSOCKAPI_ // stops windows.h from including winsock.h (and lets us include winsock2.h)
-    #define NOMINMAX // windows c++ pollutes the environment like any factory
+    #ifndef WIN32_LEAN_AND_MEAN
+      #define WIN32_LEAN_AND_MEAN // slimmer compile times
+    #endif
+
+    #ifndef _WINSOCKAPI_
+      #define _WINSOCKAPI_ // stops windows.h from including winsock.h (and lets us include winsock2.h)
+    #endif
+
+    #ifndef NOMINMAX
+      #define NOMINMAX // windows c++ pollutes the environment like any factory
+    #endif
   #endif
   #include <windows.h>
 #endif


### PR DESCRIPTION
`getenv` from `stdlib.h` is always used in the code (https://github.com/ros/roscpp_core/blob/kinetic-devel/cpp_common/include/ros/platform.h#L68), remove the `_MSC_VER` check

`windows.h` doesn't have to be included in `platform.h` since it's not used by all the files referencing `platform.h`. `WIN32_LEAN_AND_MEAN ` and `NOMINMAX ` are [changed](https://github.com/ros/catkin/pull/984/files) to be added in `catkin`. `_WINSOCKAPI_` is not really necessary since `winsock2.h` (mentioned in the comment) is not being included.