### PR TITLE
use std::this_thread::sleep_for instead of WaitableTimer

### DIFF
--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -51,6 +51,11 @@
 #include <mach/mach.h>
 #endif  // defined(__APPLE__)
 
+#ifdef _WINDOWS
+#include <chrono>
+#include <thread>
+#endif
+
 #include <boost/thread/mutex.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
@@ -228,27 +233,7 @@ namespace ros
   int ros_nanosleep(const uint32_t &sec, const uint32_t &nsec)
   {
 #if defined(WIN32)
-    HANDLE timer = NULL;
-    LARGE_INTEGER sleepTime;
-    sleepTime.QuadPart = -
-      static_cast<int64_t>(sec)*10000000LL -
-      static_cast<int64_t>(nsec) / 100LL;
-
-    timer = CreateWaitableTimer(NULL, TRUE, NULL);
-    if (timer == NULL)
-      {
-        return -1;
-      }
-
-    if (!SetWaitableTimer (timer, &sleepTime, 0, NULL, NULL, 0))
-      {
-        return -1;
-      }
-
-    if (WaitForSingleObject (timer, INFINITE) != WAIT_OBJECT_0)
-      {
-        return -1;
-      }
+    std::this_thread::sleep_for(std::chrono::nanoseconds(static_cast<int64_t>(sec * 1e9 + nsec)));
     return 0;
 #else
     timespec req = { sec, nsec };


### PR DESCRIPTION
use [`std::this_thread::sleep_for`](https://en.cppreference.com/w/cpp/thread/sleep_for) + [`std::chrono::nanoseconds`](https://en.cppreference.com/w/cpp/chrono/duration) (both supported since c++11) to replace `WaitableTimer` + `WaitForSingleObject`. While testing on Windows, `WaitableTimer` + `WaitForSingleObject` tend to have a bad accuracy, a lot of times shorter than expected (random range around the expected length); `sleep_for`, however, does not have this problem.

newly added libraries are only used inside Windows-specific code at this point, so they are guarded by the `_WINDOWS` macros (also adding in https://github.com/ros/roscpp_core/pull/100). Supposedly these 2 pull request would lead to merge conflict for each other, will merge and fix the conflict when it happens (when one of the changes gets merged =) ).
