### PR TITLE
Fix GCC8 class-memaccess warning

### DIFF
--- a/roscpp_serialization/include/ros/serialization.h
+++ b/roscpp_serialization/include/ros/serialization.h
@@ -408,7 +408,7 @@ struct VectorSerializer<T, ContainerAllocator, typename boost::enable_if<mt::IsS
     if (len > 0)
     {
       const uint32_t data_len = (uint32_t)sizeof(T) * len;
-      memcpy(&v.front(), stream.advance(data_len), data_len);
+      memcpy(static_cast<void*>(&v.front()), stream.advance(data_len), data_len);
     }
   }
 


### PR DESCRIPTION
GCC8 raises a class-memaccess warning on memcpy for objects of class
type (see
https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html).

This is related to (and fixes) https://github.com/ros/gencpp/issues/37 (I had the same issue with messages specifying a `duration[]`).

---
My GCC version on Fedora 28 is `gcc (GCC) 8.2.1 20181215 (Red Hat 8.2.1-6)`