### PR TITLE
rostime: remove empty destructor of DurationBase

### DIFF
--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -76,7 +76,6 @@ public:
   DurationBase() : sec(0), nsec(0) { }
   DurationBase(int32_t _sec, int32_t _nsec);
   explicit DurationBase(double t){fromSec(t);};
-  ~DurationBase() {}
   T operator+(const T &rhs) const;
   T operator-(const T &rhs) const;
   T operator-() const;


### PR DESCRIPTION
This makes Duration and WallDuration trivially copyable. See also #82.

This conflicts with #87.