### PR TITLE
use _WIN32 for platform detection

### DIFF
--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -50,7 +50,7 @@
 ** Cross Platform Headers
 *********************************************************************/
 
-#ifdef WIN32
+#if defined(_WIN32)
   #include <sys/timeb.h>
 #else
   #include <sys/time.h>

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -62,7 +62,7 @@
  ** Cross Platform Headers
  *********************************************************************/
 
-#ifdef WIN32
+#if defined(_WIN32)
   #include <sys/timeb.h>
 #else
   #include <sys/time.h>

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -103,7 +103,7 @@ namespace ros
    *********************************************************************/
   void ros_walltime(uint32_t& sec, uint32_t& nsec)
   {
-#ifndef WIN32
+#if !defined(_WIN32)
 #if HAS_CLOCK_GETTIME
     timespec start;
     clock_gettime(CLOCK_REALTIME, &start);
@@ -182,7 +182,7 @@ namespace ros
 
   void ros_steadytime(uint32_t& sec, uint32_t& nsec)
   {
-#ifndef WIN32
+#if !defined(_WIN32)
     timespec start;
 #if defined(__APPLE__)
     // On macOS use clock_get_time.
@@ -233,7 +233,7 @@ namespace ros
    */
   int ros_nanosleep(const uint32_t &sec, const uint32_t &nsec)
   {
-#if defined(WIN32)
+#if defined(_WIN32)
     std::this_thread::sleep_for(std::chrono::nanoseconds(static_cast<int64_t>(sec * 1e9 + nsec)));
     return 0;
 #else
@@ -249,7 +249,7 @@ namespace ros
    */
   bool ros_wallsleep(uint32_t sec, uint32_t nsec)
   {
-#if defined(WIN32)
+#if defined(_WIN32)
     ros_nanosleep(sec,nsec);
 #else
     timespec req = { sec, nsec };

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -32,7 +32,8 @@
 #include <gtest/gtest.h>
 #include <ros/rate.h>
 #include <ros/time.h>
-#ifndef _WIN32
+
+#if !defined(_WIN32)
 #include <sys/time.h>
 #endif
 
@@ -47,7 +48,7 @@ double epsilon = 1e-9;
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-#ifndef _WIN32
+#if !defined(_WIN32)
   timeval temp_time_struct;
   gettimeofday(&temp_time_struct,NULL);
   srand(temp_time_struct.tv_usec);
@@ -537,7 +538,7 @@ void alarmHandler(int sig)
 
 TEST(Duration, sleepWithSignal)
 {
-#ifndef _WIN32
+#if !defined(_WIN32)
   signal(SIGALRM, alarmHandler);
   alarm(1);
 #endif


### PR DESCRIPTION
as discussed in https://github.com/ros/roscpp_core/issues/108, `WIN32` is only introduced by `windows.h`, it is better to use `_WIN32` defined by the Visual Studio compiler for platform detection