### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/cpp_common/CMakeLists.txt
+++ b/cpp_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(cpp_common)
 
 find_package(Boost REQUIRED COMPONENTS system thread)

--- a/roscpp_core/CMakeLists.txt
+++ b/roscpp_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(roscpp_core)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/roscpp_serialization/CMakeLists.txt
+++ b/roscpp_serialization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(roscpp_serialization)
 find_package(catkin REQUIRED COMPONENTS cpp_common roscpp_traits rostime)
 catkin_package(

--- a/roscpp_traits/CMakeLists.txt
+++ b/roscpp_traits/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(roscpp_traits)
 find_package(catkin REQUIRED)
 catkin_package(

--- a/rostime/CMakeLists.txt
+++ b/rostime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rostime)
 
 find_package(catkin REQUIRED COMPONENTS cpp_common)


### PR DESCRIPTION
See ros/catkin#1052. This fixes a CMake author warning in Debian Buster and Ubuntu Focal.