### PR TITLE
only depend on the boost components needed

### DIFF
--- a/cpp_common/package.xml
+++ b/cpp_common/package.xml
@@ -17,9 +17,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
+  <build_depend>libboost-system-dev</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
 
-  <run_depend>boost</run_depend>
+  <run_depend>libboost-system-dev</run_depend>
+  <run_depend>libboost-thread-dev</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
 </package>

--- a/rostime/package.xml
+++ b/rostime/package.xml
@@ -12,9 +12,13 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
+  <build_depend>libboost-date-time-dev</build_depend>
+  <build_depend>libboost-system-dev</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
   <build_depend>cpp_common</build_depend>
 
-  <run_depend>boost</run_depend>
+  <run_depend>libboost-date-time-dev</run_depend>
+  <run_depend>libboost-system-dev</run_depend>
+  <run_depend>libboost-thread-dev</run_depend>
   <run_depend>cpp_common</run_depend>
 </package>


### PR DESCRIPTION
Using the new rosdep key for `date-time`: ros/rosdistro#23618.