### PR TITLE
Fix build warnings with recent boost libraries (>= 1.67)

### DIFF
--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -184,9 +184,9 @@ namespace ros {
   {
     namespace bt = boost::posix_time;
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
-    return bt::seconds(sec) + bt::nanoseconds(nsec);
+    return bt::seconds(sec) + bt::nanoseconds(long(nsec));
 #else
-    return bt::seconds(sec) + bt::microseconds(nsec/1000);
+    return bt::seconds(sec) + bt::microseconds(long(nsec/1000));
 #endif
   }
 }

--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -178,9 +178,9 @@ namespace ros
   {
     namespace pt = boost::posix_time;
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
-    return pt::from_time_t(sec) + pt::nanoseconds(nsec);
+    return pt::from_time_t(sec) + pt::nanoseconds(long(nsec));
 #else
-    return pt::from_time_t(sec) + pt::microseconds(nsec/1000);
+    return pt::from_time_t(sec) + pt::microseconds(long(nsec/1000));
 #endif
   }
 }


### PR DESCRIPTION
With https://github.com/boostorg/date_time/commit/f9f2aaf5216c
we need to update the usage of duration.
Reference: https://github.com/Icinga/icinga2/pull/6230

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>