### PR TITLE
 Added helpers for constructing time in milli/microseconds

### DIFF
--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -64,6 +64,16 @@ namespace ros
 ROSTIME_DECL void normalizeSecNSecSigned(int64_t& sec, int64_t& nsec);
 ROSTIME_DECL void normalizeSecNSecSigned(int32_t& sec, int32_t& nsec);
 
+// Arithmetic oprations of unsigned 32/64 bit numbers with these signed constants will convert these constants to
+// unsigned numbers according to the C standard. 16 bit unsigned numbers will get implicitly converted to int32_t for
+// the computation.
+constexpr int32_t NSecInUSec = 1000l;  //!< Number of nanoseconds in a microsecond.
+constexpr int32_t NSecInMSec = 1000000l;  //!< Number of nanoseconds in a millisecond.
+constexpr int32_t NSecInSec  = 1000000000l;  //!< Number of nanoseconds in a second.
+constexpr int32_t USecInMSec = 1000l;  //!< Number of microseconds in a millisecond.
+constexpr int32_t USecInSec  = 1000000l;  //!< Number of microseconds in a second.
+constexpr int32_t MSecInSec  = 1000l;  //!< Number of milliseconds in a second.
+
 /**
  * \brief Base class for Duration implementations.  Provides storage, common functions and operator overloads.
  * This should not need to be used directly.
@@ -90,8 +100,12 @@ public:
   bool operator>=(const T &rhs) const;
   bool operator<=(const T &rhs) const;
   double toSec() const { return static_cast<double>(sec) + 1e-9*static_cast<double>(nsec); };
+  double toMSec() const { return static_cast<double>(sec * MSecInSec) + 1e-6*static_cast<double>(nsec); };
+  double toUSec() const { return static_cast<double>(sec * USecInSec) + 1e-3*static_cast<double>(nsec); };
   int64_t toNSec() const {return static_cast<int64_t>(sec)*1000000000ll + static_cast<int64_t>(nsec);  };
   T& fromSec(double t);
+  inline T& fromMSec(int64_t milisec) { return fromNSec(milisec * NSecInMSec); }
+  inline T& fromUSec(int64_t microsec) { return fromNSec(microsec * NSecInUSec); }
   T& fromNSec(int64_t t);
   bool isZero() const;
   boost::posix_time::time_duration toBoost() const;

--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -102,7 +102,7 @@ public:
   double toSec() const { return static_cast<double>(sec) + 1e-9*static_cast<double>(nsec); };
   double toMSec() const { return static_cast<double>(sec * MSecInSec) + 1e-6*static_cast<double>(nsec); };
   double toUSec() const { return static_cast<double>(sec * USecInSec) + 1e-3*static_cast<double>(nsec); };
-  int64_t toNSec() const {return static_cast<int64_t>(sec)*1000000000ll + static_cast<int64_t>(nsec);  };
+  int64_t toNSec() const {return static_cast<int64_t>(sec)*NSecInSec + static_cast<int64_t>(nsec);  };
   T& fromSec(double t);
   inline T& fromMSec(int64_t milisec) { return fromNSec(milisec * NSecInMSec); }
   inline T& fromUSec(int64_t microsec) { return fromNSec(microsec * NSecInUSec); }

--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -67,12 +67,12 @@ ROSTIME_DECL void normalizeSecNSecSigned(int32_t& sec, int32_t& nsec);
 // Arithmetic oprations of unsigned 32/64 bit numbers with these signed constants will convert these constants to
 // unsigned numbers according to the C standard. 16 bit unsigned numbers will get implicitly converted to int32_t for
 // the computation.
-constexpr int32_t NSecInUSec = 1000l;  //!< Number of nanoseconds in a microsecond.
-constexpr int32_t NSecInMSec = 1000000l;  //!< Number of nanoseconds in a millisecond.
-constexpr int32_t NSecInSec  = 1000000000l;  //!< Number of nanoseconds in a second.
-constexpr int32_t USecInMSec = 1000l;  //!< Number of microseconds in a millisecond.
-constexpr int32_t USecInSec  = 1000000l;  //!< Number of microseconds in a second.
-constexpr int32_t MSecInSec  = 1000l;  //!< Number of milliseconds in a second.
+constexpr int32_t USEC_TO_NSEC = 1000l;  //!< Number of nanoseconds in a microsecond.
+constexpr int32_t MSEC_TO_NSEC = 1000000l;  //!< Number of nanoseconds in a millisecond.
+constexpr int32_t SEC_TO_NSEC  = 1000000000l;  //!< Number of nanoseconds in a second.
+constexpr int32_t MSEC_TO_USEC = 1000l;  //!< Number of microseconds in a millisecond.
+constexpr int32_t SEC_TO_USEC  = 1000000l;  //!< Number of microseconds in a second.
+constexpr int32_t SEC_TO_MSEC  = 1000l;  //!< Number of milliseconds in a second.
 
 /**
  * \brief Base class for Duration implementations.  Provides storage, common functions and operator overloads.
@@ -100,15 +100,20 @@ public:
   bool operator>=(const T &rhs) const;
   bool operator<=(const T &rhs) const;
   double toSec() const { return static_cast<double>(sec) + 1e-9*static_cast<double>(nsec); };
-  double toMSec() const { return static_cast<double>(sec * MSecInSec) + 1e-6*static_cast<double>(nsec); };
-  double toUSec() const { return static_cast<double>(sec * USecInSec) + 1e-3*static_cast<double>(nsec); };
-  int64_t toNSec() const {return static_cast<int64_t>(sec)*NSecInSec + static_cast<int64_t>(nsec);  };
+  double toMSec() const { return static_cast<double>(sec * SEC_TO_MSEC) + 1e-6 * static_cast<double>(nsec); };
+  double toUSec() const { return static_cast<double>(sec * SEC_TO_USEC) + 1e-3 * static_cast<double>(nsec); };
+  int64_t toNSec() const {return static_cast<int64_t>(sec) * SEC_TO_NSEC + static_cast<int64_t>(nsec);  };
   T& fromSec(double t);
-  inline T& fromMSec(int64_t milisec) { return fromNSec(milisec * NSecInMSec); }
-  inline T& fromUSec(int64_t microsec) { return fromNSec(microsec * NSecInUSec); }
+  inline T& fromMSec(int64_t milliseconds) { return fromNSec(milliseconds * MSEC_TO_NSEC); }
+  inline T& fromUSec(int64_t microseconds) { return fromNSec(microseconds * USEC_TO_NSEC); }
   T& fromNSec(int64_t t);
   bool isZero() const;
   boost::posix_time::time_duration toBoost() const;
+
+  static inline T seconds(int64_t seconds) { return T(seconds, 0); }
+  static inline T milliseconds(int64_t milliseconds) { return T(0, milliseconds * MSEC_TO_NSEC); }
+  static inline T microseconds(int64_t microseconds) { return T(0, microseconds * USEC_TO_NSEC); }
+  static inline T nanoseconds(int64_t nanoseconds) { return T(0, nanoseconds); }
 };
 
 class Rate;

--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -57,21 +57,21 @@ namespace ros {
     if (sec64 < std::numeric_limits<int32_t>::min() || sec64 > std::numeric_limits<int32_t>::max())
       throw std::runtime_error("Duration is out of dual 32-bit range");
     sec = static_cast<int32_t>(sec64);
-    nsec = static_cast<int32_t>(boost::math::round((d - sec) * 1e9));
-    int32_t rollover = nsec / 1000000000ul;
+    nsec = static_cast<int32_t>(boost::math::round((d - sec) * NSecInSec));
+    int32_t rollover = nsec / NSecInSec;
     sec += rollover;
-    nsec %= 1000000000ul;
+    nsec %= NSecInSec;
     return *static_cast<T*>(this);
   }
 
   template<class T>
   T& DurationBase<T>::fromNSec(int64_t t)
   {
-    int64_t sec64 = t / 1000000000LL;
+    int64_t sec64 = t / static_cast<int64_t>(NSecInSec);
     if (sec64 < std::numeric_limits<int32_t>::min() || sec64 > std::numeric_limits<int32_t>::max())
       throw std::runtime_error("Duration is out of dual 32-bit range");
     sec = static_cast<int32_t>(sec64);
-    nsec = static_cast<int32_t>(t % 1000000000LL);
+    nsec = static_cast<int32_t>(t % static_cast<int64_t>(NSecInSec));
 
     normalizeSecNSecSigned(sec, nsec);
 
@@ -186,7 +186,7 @@ namespace ros {
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return bt::seconds(sec) + bt::nanoseconds(nsec);
 #else
-    return bt::seconds(sec) + bt::microseconds(nsec/1000);
+    return bt::seconds(sec) + bt::microseconds(nsec/NSecInUSec);
 #endif
   }
 }

--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -57,21 +57,21 @@ namespace ros {
     if (sec64 < std::numeric_limits<int32_t>::min() || sec64 > std::numeric_limits<int32_t>::max())
       throw std::runtime_error("Duration is out of dual 32-bit range");
     sec = static_cast<int32_t>(sec64);
-    nsec = static_cast<int32_t>(boost::math::round((d - sec) * NSecInSec));
-    int32_t rollover = nsec / NSecInSec;
+    nsec = static_cast<int32_t>(boost::math::round((d - sec) * SEC_TO_NSEC));
+    int32_t rollover = nsec / SEC_TO_NSEC;
     sec += rollover;
-    nsec %= NSecInSec;
+    nsec %= SEC_TO_NSEC;
     return *static_cast<T*>(this);
   }
 
   template<class T>
   T& DurationBase<T>::fromNSec(int64_t t)
   {
-    int64_t sec64 = t / static_cast<int64_t>(NSecInSec);
+    int64_t sec64 = t / static_cast<int64_t>(SEC_TO_NSEC);
     if (sec64 < std::numeric_limits<int32_t>::min() || sec64 > std::numeric_limits<int32_t>::max())
       throw std::runtime_error("Duration is out of dual 32-bit range");
     sec = static_cast<int32_t>(sec64);
-    nsec = static_cast<int32_t>(t % static_cast<int64_t>(NSecInSec));
+    nsec = static_cast<int32_t>(t % static_cast<int64_t>(SEC_TO_NSEC));
 
     normalizeSecNSecSigned(sec, nsec);
 
@@ -186,7 +186,7 @@ namespace ros {
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return bt::seconds(sec) + bt::nanoseconds(nsec);
 #else
-    return bt::seconds(sec) + bt::microseconds(nsec/NSecInUSec);
+    return bt::seconds(sec) + bt::microseconds(nsec / USEC_TO_NSEC);
 #endif
   }
 }

--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -79,10 +79,10 @@ namespace ros
       if (sec64 < 0 || sec64 > std::numeric_limits<uint32_t>::max())
         throw std::runtime_error("Time is out of dual 32-bit range");
       sec = static_cast<uint32_t>(sec64);
-      nsec = static_cast<uint32_t>(boost::math::round((t-sec) * 1e9));
+      nsec = static_cast<uint32_t>(boost::math::round((t-sec) * NSecInSec));
       // avoid rounding errors
-      sec += (nsec / 1000000000ul);
-      nsec %= 1000000000ul;
+      sec += (nsec / NSecInSec);
+      nsec %= NSecInSec;
       return *static_cast<T*>(this);
   }
 
@@ -180,7 +180,7 @@ namespace ros
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return pt::from_time_t(sec) + pt::nanoseconds(nsec);
 #else
-    return pt::from_time_t(sec) + pt::microseconds(nsec/1000);
+    return pt::from_time_t(sec) + pt::microseconds(nsec/NSecInUSec);
 #endif
   }
 }

--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -79,10 +79,10 @@ namespace ros
       if (sec64 < 0 || sec64 > std::numeric_limits<uint32_t>::max())
         throw std::runtime_error("Time is out of dual 32-bit range");
       sec = static_cast<uint32_t>(sec64);
-      nsec = static_cast<uint32_t>(boost::math::round((t-sec) * NSecInSec));
+      nsec = static_cast<uint32_t>(boost::math::round((t-sec) * SEC_TO_NSEC));
       // avoid rounding errors
-      sec += (nsec / NSecInSec);
-      nsec %= NSecInSec;
+      sec += (nsec / SEC_TO_NSEC);
+      nsec %= SEC_TO_NSEC;
       return *static_cast<T*>(this);
   }
 
@@ -180,7 +180,7 @@ namespace ros
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     return pt::from_time_t(sec) + pt::nanoseconds(nsec);
 #else
-    return pt::from_time_t(sec) + pt::microseconds(nsec/NSecInUSec);
+    return pt::from_time_t(sec) + pt::microseconds(nsec / USEC_TO_NSEC);
 #endif
   }
 }

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -159,7 +159,7 @@ namespace ros
     double toUSec() const { return static_cast<double>(sec * USecInSec) + 1e-3*static_cast<double>(nsec); };
     inline T& fromUSec(uint64_t microsec) { return fromNSec(microsec * NSecInUSec); }
 
-    uint64_t toNSec() const {return static_cast<uint64_t>(sec)*1000000000ull + static_cast<uint64_t>(nsec); }
+    uint64_t toNSec() const {return static_cast<uint64_t>(sec)*NSecInSec + static_cast<uint64_t>(nsec); }
     T& fromNSec(uint64_t t);
 
     inline bool isZero() const { return sec == 0 && nsec == 0; }

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -153,18 +153,23 @@ namespace ros
     double toSec()  const { return static_cast<double>(sec) + 1e-9*static_cast<double>(nsec); };
     T& fromSec(double t);
 
-    double toMSec() const { return static_cast<double>(sec * MSecInSec) + 1e-6*static_cast<double>(nsec); };
-    inline T& fromMSec(uint64_t milisec) { return fromNSec(milisec * NSecInMSec); }
+    double toMSec() const { return static_cast<double>(sec * SEC_TO_MSEC) + 1e-6 * static_cast<double>(nsec); };
+    inline T& fromMSec(uint64_t milisec) { return fromNSec(milisec * MSEC_TO_NSEC); }
 
-    double toUSec() const { return static_cast<double>(sec * USecInSec) + 1e-3*static_cast<double>(nsec); };
-    inline T& fromUSec(uint64_t microsec) { return fromNSec(microsec * NSecInUSec); }
+    double toUSec() const { return static_cast<double>(sec * SEC_TO_USEC) + 1e-3 * static_cast<double>(nsec); };
+    inline T& fromUSec(uint64_t microsec) { return fromNSec(microsec * USEC_TO_NSEC); }
 
-    uint64_t toNSec() const {return static_cast<uint64_t>(sec)*NSecInSec + static_cast<uint64_t>(nsec); }
+    uint64_t toNSec() const {return static_cast<uint64_t>(sec) * SEC_TO_NSEC + static_cast<uint64_t>(nsec); }
     T& fromNSec(uint64_t t);
 
     inline bool isZero() const { return sec == 0 && nsec == 0; }
     inline bool is_zero() const { return isZero(); }
     boost::posix_time::ptime toBoost() const;
+
+    static inline T seconds(uint64_t seconds) { return T(seconds, 0); }
+    static inline T milliseconds(uint64_t milliseconds) { return T(0, milliseconds * MSEC_TO_NSEC); }
+    static inline T microseconds(uint64_t microseconds) { return T(0, microseconds * USEC_TO_NSEC); }
+    static inline T nanoseconds(uint64_t nanoseconds) { return T(0, nanoseconds); }
 
   };
 

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -153,6 +153,12 @@ namespace ros
     double toSec()  const { return static_cast<double>(sec) + 1e-9*static_cast<double>(nsec); };
     T& fromSec(double t);
 
+    double toMSec() const { return static_cast<double>(sec * MSecInSec) + 1e-6*static_cast<double>(nsec); };
+    inline T& fromMSec(uint64_t milisec) { return fromNSec(milisec * NSecInMSec); }
+
+    double toUSec() const { return static_cast<double>(sec * USecInSec) + 1e-3*static_cast<double>(nsec); };
+    inline T& fromUSec(uint64_t microsec) { return fromNSec(microsec * NSecInUSec); }
+
     uint64_t toNSec() const {return static_cast<uint64_t>(sec)*1000000000ull + static_cast<uint64_t>(nsec); }
     T& fromNSec(uint64_t t);
 

--- a/rostime/src/duration.cpp
+++ b/rostime/src/duration.cpp
@@ -46,11 +46,11 @@ namespace ros {
 
   void normalizeSecNSecSigned(int64_t& sec, int64_t& nsec)
   {
-    int64_t nsec_part = nsec % NSecInSec;
-    int64_t sec_part = sec + nsec / NSecInSec;
+    int64_t nsec_part = nsec % SEC_TO_NSEC;
+    int64_t sec_part = sec + nsec / SEC_TO_NSEC;
     if (nsec_part < 0)
       {
-        nsec_part += NSecInSec;
+        nsec_part += SEC_TO_NSEC;
         --sec_part;
       }
 

--- a/rostime/src/duration.cpp
+++ b/rostime/src/duration.cpp
@@ -46,11 +46,11 @@ namespace ros {
 
   void normalizeSecNSecSigned(int64_t& sec, int64_t& nsec)
   {
-    int64_t nsec_part = nsec % 1000000000L;
-    int64_t sec_part = sec + nsec / 1000000000L;
+    int64_t nsec_part = nsec % NSecInSec;
+    int64_t sec_part = sec + nsec / NSecInSec;
     if (nsec_part < 0)
       {
-        nsec_part += 1000000000L;
+        nsec_part += NSecInSec;
         --sec_part;
       }
 

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -80,10 +80,10 @@ namespace ros
    ** Variables
    *********************************************************************/
 
-  const Duration DURATION_MAX(std::numeric_limits<int32_t>::max(), NSecInSec - 1);
+  const Duration DURATION_MAX(std::numeric_limits<int32_t>::max(), SEC_TO_NSEC - 1);
   const Duration DURATION_MIN(std::numeric_limits<int32_t>::min(), 0);
 
-  const Time TIME_MAX(std::numeric_limits<uint32_t>::max(), NSecInSec - 1);
+  const Time TIME_MAX(std::numeric_limits<uint32_t>::max(), SEC_TO_NSEC - 1);
   const Time TIME_MIN(0, 1);
 
   // This is declared here because it's set from the Time class but read from
@@ -117,7 +117,7 @@ namespace ros
     if (timeofday.tv_sec < 0 || timeofday.tv_sec > std::numeric_limits<uint32_t>::max())
       throw std::runtime_error("Timeofday is out of dual signed 32-bit range");
     sec  = timeofday.tv_sec;
-    nsec = timeofday.tv_usec * NSecInUSec;
+    nsec = timeofday.tv_usec * USEC_TO_NSEC;
 #endif
 #else
     uint64_t now_s = 0;
@@ -171,7 +171,7 @@ namespace ros
   int ros_nanosleep(const uint32_t &sec, const uint32_t &nsec)
   {
 #if defined(_WIN32)
-    std::this_thread::sleep_for(std::chrono::nanoseconds(static_cast<int64_t>(sec * NSecInSec + nsec)));
+    std::this_thread::sleep_for(std::chrono::nanoseconds(static_cast<int64_t>(sec * SEC_TO_NSEC + nsec)));
     return 0;
 #else
     timespec req = { sec, nsec };
@@ -305,7 +305,7 @@ namespace ros
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     t.nsec = d.fractional_seconds();
 #else
-    t.nsec = d.fractional_seconds()*NSecInUSec;
+    t.nsec = d.fractional_seconds() * USEC_TO_NSEC;
 #endif
     return t;
   }
@@ -326,7 +326,7 @@ namespace ros
     }
     else
     {
-      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (NSecInSec - rhs.nsec);
+      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (SEC_TO_NSEC - rhs.nsec);
     }
     return os;
   }
@@ -348,7 +348,7 @@ namespace ros
       Time start = Time::now();
       while (!g_stopped && (Time::now() < end))
       {
-        ros_nanosleep(0,NSecInMSec);
+        ros_nanosleep(0, MSEC_TO_NSEC);
         if (Time::now() < start)
         {
           return false;
@@ -399,7 +399,7 @@ namespace ros
       bool rc = false;
       while (!g_stopped && (Time::now() < end))
       {
-        ros_wallsleep(0, NSecInMSec);
+        ros_wallsleep(0, MSEC_TO_NSEC);
         rc = true;
 
         // If we started at time 0 wait for the first actual time to arrive before starting the timer on
@@ -460,7 +460,7 @@ namespace ros
     }
     else
     {
-      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (NSecInSec - rhs.nsec);
+      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (SEC_TO_NSEC - rhs.nsec);
     }
     return os;
   }
@@ -472,8 +472,8 @@ namespace ros
 
   void normalizeSecNSec(uint64_t& sec, uint64_t& nsec)
   {
-    uint64_t nsec_part = nsec % NSecInSec;
-    uint64_t sec_part = nsec / NSecInSec;
+    uint64_t nsec_part = nsec % SEC_TO_NSEC;
+    uint64_t sec_part = nsec / SEC_TO_NSEC;
 
     if (sec + sec_part > std::numeric_limits<uint32_t>::max())
       throw std::runtime_error("Time is out of dual 32-bit range");
@@ -495,11 +495,11 @@ namespace ros
 
   void normalizeSecNSecUnsigned(int64_t& sec, int64_t& nsec)
   {
-    int64_t nsec_part = nsec % NSecInSec;
-    int64_t sec_part = sec + nsec / NSecInSec;
+    int64_t nsec_part = nsec % SEC_TO_NSEC;
+    int64_t sec_part = sec + nsec / SEC_TO_NSEC;
     if (nsec_part < 0)
       {
-        nsec_part += NSecInSec;
+        nsec_part += SEC_TO_NSEC;
         --sec_part;
       }
 

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -80,10 +80,10 @@ namespace ros
    ** Variables
    *********************************************************************/
 
-  const Duration DURATION_MAX(std::numeric_limits<int32_t>::max(), 999999999);
+  const Duration DURATION_MAX(std::numeric_limits<int32_t>::max(), NSecInSec - 1);
   const Duration DURATION_MIN(std::numeric_limits<int32_t>::min(), 0);
 
-  const Time TIME_MAX(std::numeric_limits<uint32_t>::max(), 999999999);
+  const Time TIME_MAX(std::numeric_limits<uint32_t>::max(), NSecInSec - 1);
   const Time TIME_MIN(0, 1);
 
   // This is declared here because it's set from the Time class but read from
@@ -117,7 +117,7 @@ namespace ros
     if (timeofday.tv_sec < 0 || timeofday.tv_sec > std::numeric_limits<uint32_t>::max())
       throw std::runtime_error("Timeofday is out of dual signed 32-bit range");
     sec  = timeofday.tv_sec;
-    nsec = timeofday.tv_usec * 1000;
+    nsec = timeofday.tv_usec * NSecInUSec;
 #endif
 #else
     uint64_t now_s = 0;
@@ -171,7 +171,7 @@ namespace ros
   int ros_nanosleep(const uint32_t &sec, const uint32_t &nsec)
   {
 #if defined(_WIN32)
-    std::this_thread::sleep_for(std::chrono::nanoseconds(static_cast<int64_t>(sec * 1e9 + nsec)));
+    std::this_thread::sleep_for(std::chrono::nanoseconds(static_cast<int64_t>(sec * NSecInSec + nsec)));
     return 0;
 #else
     timespec req = { sec, nsec };
@@ -305,7 +305,7 @@ namespace ros
 #if defined(BOOST_DATE_TIME_HAS_NANOSECONDS)
     t.nsec = d.fractional_seconds();
 #else
-    t.nsec = d.fractional_seconds()*1000;
+    t.nsec = d.fractional_seconds()*NSecInUSec;
 #endif
     return t;
   }
@@ -326,7 +326,7 @@ namespace ros
     }
     else
     {
-      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (1000000000 - rhs.nsec);
+      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (NSecInSec - rhs.nsec);
     }
     return os;
   }
@@ -348,7 +348,7 @@ namespace ros
       Time start = Time::now();
       while (!g_stopped && (Time::now() < end))
       {
-        ros_nanosleep(0,1000000);
+        ros_nanosleep(0,NSecInMSec);
         if (Time::now() < start)
         {
           return false;
@@ -399,7 +399,7 @@ namespace ros
       bool rc = false;
       while (!g_stopped && (Time::now() < end))
       {
-        ros_wallsleep(0, 1000000);
+        ros_wallsleep(0, NSecInMSec);
         rc = true;
 
         // If we started at time 0 wait for the first actual time to arrive before starting the timer on
@@ -460,7 +460,7 @@ namespace ros
     }
     else
     {
-      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (1000000000 - rhs.nsec);
+      os << (rhs.sec == -1 ? "-" : "") << (rhs.sec + 1) << "." << std::setw(9) << std::setfill('0') << (NSecInSec - rhs.nsec);
     }
     return os;
   }
@@ -472,8 +472,8 @@ namespace ros
 
   void normalizeSecNSec(uint64_t& sec, uint64_t& nsec)
   {
-    uint64_t nsec_part = nsec % 1000000000UL;
-    uint64_t sec_part = nsec / 1000000000UL;
+    uint64_t nsec_part = nsec % NSecInSec;
+    uint64_t sec_part = nsec / NSecInSec;
 
     if (sec + sec_part > std::numeric_limits<uint32_t>::max())
       throw std::runtime_error("Time is out of dual 32-bit range");
@@ -495,11 +495,11 @@ namespace ros
 
   void normalizeSecNSecUnsigned(int64_t& sec, int64_t& nsec)
   {
-    int64_t nsec_part = nsec % 1000000000L;
-    int64_t sec_part = sec + nsec / 1000000000L;
+    int64_t nsec_part = nsec % NSecInSec;
+    int64_t sec_part = sec + nsec / NSecInSec;
     if (nsec_part < 0)
       {
-        nsec_part += 1000000000L;
+        nsec_part += NSecInSec;
         --sec_part;
       }
 

--- a/rostime/test/duration.cpp
+++ b/rostime/test/duration.cpp
@@ -89,7 +89,7 @@ TEST(Duration, arithmeticExceptions)
   ros::Time::init();
 
   Duration d1(2147483647, 0);
-  Duration d2(2147483647, 999999999);
+  Duration d2(2147483647, NSecInSec - 1);
   EXPECT_THROW(d1 + d2, std::runtime_error);
 
   Duration d3(-2147483648, 0);
@@ -98,7 +98,7 @@ TEST(Duration, arithmeticExceptions)
   EXPECT_THROW(d4 - d3, std::runtime_error);
 
   Duration d5(-2147483647, 1);
-  Duration d6(-2, 999999999);
+  Duration d6(-2, NSecInSec - 1);
   Duration d7;
   EXPECT_NO_THROW(d7 = d5 + d6);
   EXPECT_EQ(-2147483648000000000, d7.toNSec());
@@ -109,7 +109,7 @@ TEST(Duration, negativeSignExceptions)
   ros::Time::init();
 
   Duration d1(2147483647, 0);
-  Duration d2(2147483647, 999999999);
+  Duration d2(2147483647, NSecInSec - 1);
   Duration d3;
   EXPECT_NO_THROW(d3 = -d1);
   EXPECT_EQ(-2147483647000000000, d3.toNSec());
@@ -117,7 +117,7 @@ TEST(Duration, negativeSignExceptions)
   EXPECT_EQ(-2147483647999999999, d3.toNSec());
 
   Duration d4(-2147483647, 0);
-  Duration d5(-2147483648, 999999999);
+  Duration d5(-2147483648, NSecInSec - 1);
   Duration d6(-2147483648, 2);
   Duration d7;
   EXPECT_NO_THROW(d7 = -d4);
@@ -144,11 +144,11 @@ TEST(Duration, rounding)
   EXPECT_EQ(1, d3.nsec);
   Duration d4(-49.0000000006);
   EXPECT_EQ(-50, d4.sec);
-  EXPECT_EQ(999999999, d4.nsec);
+  EXPECT_EQ(NSecInSec - 1, d4.nsec);
 
   Duration d5(49.9999999994);
   EXPECT_EQ(49, d5.sec);
-  EXPECT_EQ(999999999, d5.nsec);
+  EXPECT_EQ(NSecInSec - 1, d5.nsec);
   Duration d6(-49.9999999994);
   EXPECT_EQ(-50, d6.sec);
   EXPECT_EQ(1, d6.nsec);
@@ -159,6 +159,106 @@ TEST(Duration, rounding)
   Duration d8(-49.9999999996);
   EXPECT_EQ(-50, d8.sec);
   EXPECT_EQ(0, d8.nsec);
+}
+
+TEST(Duration, construct)
+{
+  ros::Time::init();
+
+  EXPECT_EQ(Duration().fromSec(2.0), Duration(2, 0));
+  EXPECT_EQ(Duration().fromSec(-2.0), Duration(-2, 0));
+  EXPECT_EQ(Duration().fromSec(2), Duration(2, 0));
+  EXPECT_EQ(Duration().fromSec(-2), Duration(-2, 0));
+  EXPECT_EQ(Duration().fromMSec(2), Duration(0, 2 * NSecInMSec));
+  EXPECT_EQ(Duration().fromMSec(-2), Duration(0, -2 * NSecInMSec));
+  EXPECT_EQ(Duration().fromUSec(2), Duration(0, 2 * NSecInUSec));
+  EXPECT_EQ(Duration().fromUSec(-2), Duration(0, -2 * NSecInUSec));
+
+  EXPECT_EQ(WallDuration().fromSec(2.0), WallDuration(2, 0));
+  EXPECT_EQ(WallDuration().fromSec(-2.0), WallDuration(-2, 0));
+  EXPECT_EQ(WallDuration().fromSec(2), WallDuration(2, 0));
+  EXPECT_EQ(WallDuration().fromSec(-2), WallDuration(-2, 0));
+  EXPECT_EQ(WallDuration().fromMSec(2), WallDuration(0, 2 * NSecInMSec));
+  EXPECT_EQ(WallDuration().fromMSec(-2), WallDuration(0, -2 * NSecInMSec));
+  EXPECT_EQ(WallDuration().fromUSec(2), WallDuration(0, 2 * NSecInUSec));
+  EXPECT_EQ(WallDuration().fromUSec(-2), WallDuration(0, -2 * NSecInUSec));
+}
+
+TEST(Duration, toDouble)
+{
+  ros::Time::init();
+
+  EXPECT_NEAR(Duration(2, 0).toSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Duration(-2, 0).toSec(), -2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * NSecInMSec).toSec(), -0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * NSecInUSec).toSec(), -0.000002, 1e-9);
+  EXPECT_NEAR(Duration(0, 2).toSec(), 0.000000002, 1e-12);
+  EXPECT_NEAR(Duration(0, -2).toSec(), -0.000000002, 1e-12);
+
+  EXPECT_NEAR(Duration(2, 0).toMSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(Duration(-2, 0).toMSec(), -2000.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * NSecInMSec).toMSec(), -2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * NSecInUSec).toMSec(), -0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, 2).toMSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2).toMSec(), -0.000002, 1e-9);
+
+  EXPECT_NEAR(Duration(2, 0).toUSec(), 2000000.0, 1e-9);
+  EXPECT_NEAR(Duration(-2, 0).toUSec(), -2000000.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * NSecInMSec).toUSec(), -2000.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * NSecInUSec).toUSec(), -2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2).toUSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2).toUSec(), -0.002, 1e-9);
+
+  EXPECT_EQ(Duration(2, 0).toNSec(), 2000000000LL);
+  EXPECT_EQ(Duration(-2, 0).toNSec(), -2000000000LL);
+  EXPECT_EQ(Duration(0, 2 * NSecInMSec).toNSec(), 2000000LL);
+  EXPECT_EQ(Duration(0, -2 * NSecInMSec).toNSec(), -2000000LL);
+  EXPECT_EQ(Duration(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(Duration(0, -2 * NSecInUSec).toNSec(), -2000LL);
+  EXPECT_EQ(Duration(0, 2).toNSec(), 2LL);
+  EXPECT_EQ(Duration(0, -2).toNSec(), -2LL);
+
+  EXPECT_NEAR(WallDuration(2, 0).toSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(-2, 0).toSec(), -2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * NSecInMSec).toSec(), -0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * NSecInUSec).toSec(), -0.000002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2).toSec(), 0.000000002, 1e-12);
+  EXPECT_NEAR(WallDuration(0, -2).toSec(), -0.000000002, 1e-12);
+
+  EXPECT_NEAR(WallDuration(2, 0).toMSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(-2, 0).toMSec(), -2000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * NSecInMSec).toMSec(), -2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * NSecInUSec).toMSec(), -0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2).toMSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2).toMSec(), -0.000002, 1e-9);
+
+  EXPECT_NEAR(WallDuration(2, 0).toUSec(), 2000000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(-2, 0).toUSec(), -2000000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * NSecInMSec).toUSec(), -2000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * NSecInUSec).toUSec(), -2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2).toUSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2).toUSec(), -0.002, 1e-9);
+
+  EXPECT_EQ(WallDuration(2, 0).toNSec(), 2000000000LL);
+  EXPECT_EQ(WallDuration(-2, 0).toNSec(), -2000000000LL);
+  EXPECT_EQ(WallDuration(0, 2 * NSecInMSec).toNSec(), 2000000LL);
+  EXPECT_EQ(WallDuration(0, -2 * NSecInMSec).toNSec(), -2000000LL);
+  EXPECT_EQ(WallDuration(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(WallDuration(0, -2 * NSecInUSec).toNSec(), -2000LL);
+  EXPECT_EQ(WallDuration(0, 2).toNSec(), 2LL);
+  EXPECT_EQ(WallDuration(0, -2).toNSec(), -2LL);
 }
 
 int main(int argc, char **argv){

--- a/rostime/test/duration.cpp
+++ b/rostime/test/duration.cpp
@@ -89,7 +89,7 @@ TEST(Duration, arithmeticExceptions)
   ros::Time::init();
 
   Duration d1(2147483647, 0);
-  Duration d2(2147483647, NSecInSec - 1);
+  Duration d2(2147483647, SEC_TO_NSEC - 1);
   EXPECT_THROW(d1 + d2, std::runtime_error);
 
   Duration d3(-2147483648, 0);
@@ -98,7 +98,7 @@ TEST(Duration, arithmeticExceptions)
   EXPECT_THROW(d4 - d3, std::runtime_error);
 
   Duration d5(-2147483647, 1);
-  Duration d6(-2, NSecInSec - 1);
+  Duration d6(-2, SEC_TO_NSEC - 1);
   Duration d7;
   EXPECT_NO_THROW(d7 = d5 + d6);
   EXPECT_EQ(-2147483648000000000, d7.toNSec());
@@ -109,7 +109,7 @@ TEST(Duration, negativeSignExceptions)
   ros::Time::init();
 
   Duration d1(2147483647, 0);
-  Duration d2(2147483647, NSecInSec - 1);
+  Duration d2(2147483647, SEC_TO_NSEC - 1);
   Duration d3;
   EXPECT_NO_THROW(d3 = -d1);
   EXPECT_EQ(-2147483647000000000, d3.toNSec());
@@ -117,7 +117,7 @@ TEST(Duration, negativeSignExceptions)
   EXPECT_EQ(-2147483647999999999, d3.toNSec());
 
   Duration d4(-2147483647, 0);
-  Duration d5(-2147483648, NSecInSec - 1);
+  Duration d5(-2147483648, SEC_TO_NSEC - 1);
   Duration d6(-2147483648, 2);
   Duration d7;
   EXPECT_NO_THROW(d7 = -d4);
@@ -144,11 +144,11 @@ TEST(Duration, rounding)
   EXPECT_EQ(1, d3.nsec);
   Duration d4(-49.0000000006);
   EXPECT_EQ(-50, d4.sec);
-  EXPECT_EQ(NSecInSec - 1, d4.nsec);
+  EXPECT_EQ(SEC_TO_NSEC - 1, d4.nsec);
 
   Duration d5(49.9999999994);
   EXPECT_EQ(49, d5.sec);
-  EXPECT_EQ(NSecInSec - 1, d5.nsec);
+  EXPECT_EQ(SEC_TO_NSEC - 1, d5.nsec);
   Duration d6(-49.9999999994);
   EXPECT_EQ(-50, d6.sec);
   EXPECT_EQ(1, d6.nsec);
@@ -169,19 +169,41 @@ TEST(Duration, construct)
   EXPECT_EQ(Duration().fromSec(-2.0), Duration(-2, 0));
   EXPECT_EQ(Duration().fromSec(2), Duration(2, 0));
   EXPECT_EQ(Duration().fromSec(-2), Duration(-2, 0));
-  EXPECT_EQ(Duration().fromMSec(2), Duration(0, 2 * NSecInMSec));
-  EXPECT_EQ(Duration().fromMSec(-2), Duration(0, -2 * NSecInMSec));
-  EXPECT_EQ(Duration().fromUSec(2), Duration(0, 2 * NSecInUSec));
-  EXPECT_EQ(Duration().fromUSec(-2), Duration(0, -2 * NSecInUSec));
+  EXPECT_EQ(Duration().fromMSec(2), Duration(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(Duration().fromMSec(-2), Duration(0, -2 * MSEC_TO_NSEC));
+  EXPECT_EQ(Duration().fromUSec(2), Duration(0, 2 * USEC_TO_NSEC));
+  EXPECT_EQ(Duration().fromUSec(-2), Duration(0, -2 * USEC_TO_NSEC));
 
   EXPECT_EQ(WallDuration().fromSec(2.0), WallDuration(2, 0));
   EXPECT_EQ(WallDuration().fromSec(-2.0), WallDuration(-2, 0));
   EXPECT_EQ(WallDuration().fromSec(2), WallDuration(2, 0));
   EXPECT_EQ(WallDuration().fromSec(-2), WallDuration(-2, 0));
-  EXPECT_EQ(WallDuration().fromMSec(2), WallDuration(0, 2 * NSecInMSec));
-  EXPECT_EQ(WallDuration().fromMSec(-2), WallDuration(0, -2 * NSecInMSec));
-  EXPECT_EQ(WallDuration().fromUSec(2), WallDuration(0, 2 * NSecInUSec));
-  EXPECT_EQ(WallDuration().fromUSec(-2), WallDuration(0, -2 * NSecInUSec));
+  EXPECT_EQ(WallDuration().fromMSec(2), WallDuration(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(WallDuration().fromMSec(-2), WallDuration(0, -2 * MSEC_TO_NSEC));
+  EXPECT_EQ(WallDuration().fromUSec(2), WallDuration(0, 2 * USEC_TO_NSEC));
+  EXPECT_EQ(WallDuration().fromUSec(-2), WallDuration(0, -2 * USEC_TO_NSEC));
+
+  EXPECT_EQ(Duration::seconds(2.0), Duration(2, 0));
+  EXPECT_EQ(Duration::seconds(-2.0), Duration(-2, 0));
+  EXPECT_EQ(Duration::seconds(2), Duration(2, 0));
+  EXPECT_EQ(Duration::seconds(-2), Duration(-2, 0));
+  EXPECT_EQ(Duration::milliseconds(2), Duration(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(Duration::milliseconds(-2), Duration(0, -2 * MSEC_TO_NSEC));
+  EXPECT_EQ(Duration::microseconds(2), Duration(0, 2 * USEC_TO_NSEC));
+  EXPECT_EQ(Duration::microseconds(-2), Duration(0, -2 * USEC_TO_NSEC));
+  EXPECT_EQ(Duration::nanoseconds(2), Duration(0, 2));
+  EXPECT_EQ(Duration::nanoseconds(-2), Duration(0, -2));
+
+  EXPECT_EQ(WallDuration::seconds(2.0), WallDuration(2, 0));
+  EXPECT_EQ(WallDuration::seconds(-2.0), WallDuration(-2, 0));
+  EXPECT_EQ(WallDuration::seconds(2), WallDuration(2, 0));
+  EXPECT_EQ(WallDuration::seconds(-2), WallDuration(-2, 0));
+  EXPECT_EQ(WallDuration::milliseconds(2), WallDuration(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(WallDuration::milliseconds(-2), WallDuration(0, -2 * MSEC_TO_NSEC));
+  EXPECT_EQ(WallDuration::microseconds(2), WallDuration(0, 2 * USEC_TO_NSEC));
+  EXPECT_EQ(WallDuration::microseconds(-2), WallDuration(0, -2 * USEC_TO_NSEC));
+  EXPECT_EQ(WallDuration::nanoseconds(2), WallDuration(0, 2));
+  EXPECT_EQ(WallDuration::nanoseconds(-2), WallDuration(0, -2));
 }
 
 TEST(Duration, toDouble)
@@ -190,73 +212,73 @@ TEST(Duration, toDouble)
 
   EXPECT_NEAR(Duration(2, 0).toSec(), 2.0, 1e-9);
   EXPECT_NEAR(Duration(-2, 0).toSec(), -2.0, 1e-9);
-  EXPECT_NEAR(Duration(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
-  EXPECT_NEAR(Duration(0, -2 * NSecInMSec).toSec(), -0.002, 1e-9);
-  EXPECT_NEAR(Duration(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
-  EXPECT_NEAR(Duration(0, -2 * NSecInUSec).toSec(), -0.000002, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * MSEC_TO_NSEC).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * MSEC_TO_NSEC).toSec(), -0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * USEC_TO_NSEC).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * USEC_TO_NSEC).toSec(), -0.000002, 1e-9);
   EXPECT_NEAR(Duration(0, 2).toSec(), 0.000000002, 1e-12);
   EXPECT_NEAR(Duration(0, -2).toSec(), -0.000000002, 1e-12);
 
   EXPECT_NEAR(Duration(2, 0).toMSec(), 2000.0, 1e-9);
   EXPECT_NEAR(Duration(-2, 0).toMSec(), -2000.0, 1e-9);
-  EXPECT_NEAR(Duration(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
-  EXPECT_NEAR(Duration(0, -2 * NSecInMSec).toMSec(), -2.0, 1e-9);
-  EXPECT_NEAR(Duration(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
-  EXPECT_NEAR(Duration(0, -2 * NSecInUSec).toMSec(), -0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * MSEC_TO_NSEC).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * MSEC_TO_NSEC).toMSec(), -2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * USEC_TO_NSEC).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * USEC_TO_NSEC).toMSec(), -0.002, 1e-9);
   EXPECT_NEAR(Duration(0, 2).toMSec(), 0.000002, 1e-9);
   EXPECT_NEAR(Duration(0, -2).toMSec(), -0.000002, 1e-9);
 
   EXPECT_NEAR(Duration(2, 0).toUSec(), 2000000.0, 1e-9);
   EXPECT_NEAR(Duration(-2, 0).toUSec(), -2000000.0, 1e-9);
-  EXPECT_NEAR(Duration(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(Duration(0, -2 * NSecInMSec).toUSec(), -2000.0, 1e-9);
-  EXPECT_NEAR(Duration(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
-  EXPECT_NEAR(Duration(0, -2 * NSecInUSec).toUSec(), -2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * MSEC_TO_NSEC).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * MSEC_TO_NSEC).toUSec(), -2000.0, 1e-9);
+  EXPECT_NEAR(Duration(0, 2 * USEC_TO_NSEC).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Duration(0, -2 * USEC_TO_NSEC).toUSec(), -2.0, 1e-9);
   EXPECT_NEAR(Duration(0, 2).toUSec(), 0.002, 1e-9);
   EXPECT_NEAR(Duration(0, -2).toUSec(), -0.002, 1e-9);
 
   EXPECT_EQ(Duration(2, 0).toNSec(), 2000000000LL);
   EXPECT_EQ(Duration(-2, 0).toNSec(), -2000000000LL);
-  EXPECT_EQ(Duration(0, 2 * NSecInMSec).toNSec(), 2000000LL);
-  EXPECT_EQ(Duration(0, -2 * NSecInMSec).toNSec(), -2000000LL);
-  EXPECT_EQ(Duration(0, 2 * NSecInUSec).toNSec(), 2000LL);
-  EXPECT_EQ(Duration(0, -2 * NSecInUSec).toNSec(), -2000LL);
+  EXPECT_EQ(Duration(0, 2 * MSEC_TO_NSEC).toNSec(), 2000000LL);
+  EXPECT_EQ(Duration(0, -2 * MSEC_TO_NSEC).toNSec(), -2000000LL);
+  EXPECT_EQ(Duration(0, 2 * USEC_TO_NSEC).toNSec(), 2000LL);
+  EXPECT_EQ(Duration(0, -2 * USEC_TO_NSEC).toNSec(), -2000LL);
   EXPECT_EQ(Duration(0, 2).toNSec(), 2LL);
   EXPECT_EQ(Duration(0, -2).toNSec(), -2LL);
 
   EXPECT_NEAR(WallDuration(2, 0).toSec(), 2.0, 1e-9);
   EXPECT_NEAR(WallDuration(-2, 0).toSec(), -2.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
-  EXPECT_NEAR(WallDuration(0, -2 * NSecInMSec).toSec(), -0.002, 1e-9);
-  EXPECT_NEAR(WallDuration(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
-  EXPECT_NEAR(WallDuration(0, -2 * NSecInUSec).toSec(), -0.000002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * MSEC_TO_NSEC).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * MSEC_TO_NSEC).toSec(), -0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * USEC_TO_NSEC).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * USEC_TO_NSEC).toSec(), -0.000002, 1e-9);
   EXPECT_NEAR(WallDuration(0, 2).toSec(), 0.000000002, 1e-12);
   EXPECT_NEAR(WallDuration(0, -2).toSec(), -0.000000002, 1e-12);
 
   EXPECT_NEAR(WallDuration(2, 0).toMSec(), 2000.0, 1e-9);
   EXPECT_NEAR(WallDuration(-2, 0).toMSec(), -2000.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, -2 * NSecInMSec).toMSec(), -2.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
-  EXPECT_NEAR(WallDuration(0, -2 * NSecInUSec).toMSec(), -0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * MSEC_TO_NSEC).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * MSEC_TO_NSEC).toMSec(), -2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * USEC_TO_NSEC).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * USEC_TO_NSEC).toMSec(), -0.002, 1e-9);
   EXPECT_NEAR(WallDuration(0, 2).toMSec(), 0.000002, 1e-9);
   EXPECT_NEAR(WallDuration(0, -2).toMSec(), -0.000002, 1e-9);
 
   EXPECT_NEAR(WallDuration(2, 0).toUSec(), 2000000.0, 1e-9);
   EXPECT_NEAR(WallDuration(-2, 0).toUSec(), -2000000.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, -2 * NSecInMSec).toUSec(), -2000.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
-  EXPECT_NEAR(WallDuration(0, -2 * NSecInUSec).toUSec(), -2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * MSEC_TO_NSEC).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * MSEC_TO_NSEC).toUSec(), -2000.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, 2 * USEC_TO_NSEC).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallDuration(0, -2 * USEC_TO_NSEC).toUSec(), -2.0, 1e-9);
   EXPECT_NEAR(WallDuration(0, 2).toUSec(), 0.002, 1e-9);
   EXPECT_NEAR(WallDuration(0, -2).toUSec(), -0.002, 1e-9);
 
   EXPECT_EQ(WallDuration(2, 0).toNSec(), 2000000000LL);
   EXPECT_EQ(WallDuration(-2, 0).toNSec(), -2000000000LL);
-  EXPECT_EQ(WallDuration(0, 2 * NSecInMSec).toNSec(), 2000000LL);
-  EXPECT_EQ(WallDuration(0, -2 * NSecInMSec).toNSec(), -2000000LL);
-  EXPECT_EQ(WallDuration(0, 2 * NSecInUSec).toNSec(), 2000LL);
-  EXPECT_EQ(WallDuration(0, -2 * NSecInUSec).toNSec(), -2000LL);
+  EXPECT_EQ(WallDuration(0, 2 * MSEC_TO_NSEC).toNSec(), 2000000LL);
+  EXPECT_EQ(WallDuration(0, -2 * MSEC_TO_NSEC).toNSec(), -2000000LL);
+  EXPECT_EQ(WallDuration(0, 2 * USEC_TO_NSEC).toNSec(), 2000LL);
+  EXPECT_EQ(WallDuration(0, -2 * USEC_TO_NSEC).toNSec(), -2000LL);
   EXPECT_EQ(WallDuration(0, 2).toNSec(), 2LL);
   EXPECT_EQ(WallDuration(0, -2).toNSec(), -2LL);
 }

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -66,8 +66,8 @@ void generate_rand_times(uint32_t range, uint64_t runs, std::vector<ros::Time>& 
   values2.reserve(runs);
   for ( uint32_t i = 0; i < runs ; i++ )
   {
-    values1.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * 1000000000ULL/RAND_MAX)));
-    values2.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * 1000000000ULL/RAND_MAX)));
+    values1.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * NSecInSec/RAND_MAX)));
+    values2.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * NSecInSec/RAND_MAX)));
   }
 }
 
@@ -81,26 +81,26 @@ void generate_rand_durations(uint32_t range, uint64_t runs, std::vector<ros::Dur
   for ( uint32_t i = 0; i < runs ; i++ )
   {
     // positive durations
-    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * 1000000000ULL/RAND_MAX)));
-    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * 1000000000ULL/RAND_MAX)));
+    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
+    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
     EXPECT_GE(values1.back(), ros::Duration(0,0));
     EXPECT_GE(values2.back(), ros::Duration(0,0));
 
     // negative durations
-    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * 1000000000ULL/RAND_MAX)));
-    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * 1000000000ULL/RAND_MAX)));
+    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
+    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
     EXPECT_LE(values1.back(), ros::Duration(0,0));
     EXPECT_LE(values2.back(), ros::Duration(0,0));
 
     // positive and negative durations
-    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * 1000000000ULL/RAND_MAX)));
-    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * 1000000000ULL/RAND_MAX)));
+    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
+    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
     EXPECT_GE(values1.back(), ros::Duration(0,0));
     EXPECT_LE(values2.back(), ros::Duration(0,0));
 
     // negative and positive durations
-    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * 1000000000ULL/RAND_MAX)));
-    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * 1000000000ULL/RAND_MAX)));
+    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
+    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
     EXPECT_LE(values1.back(), ros::Duration(0,0));
     EXPECT_GE(values2.back(), ros::Duration(0,0));
   }
@@ -120,15 +120,15 @@ TEST(Time, Comparitors)
 
   for (uint32_t i = 0; i < v1.size(); i++)
   {
-    if (v1[i].sec * 1000000000ULL + v1[i].nsec < v2[i].sec * 1000000000ULL + v2[i].nsec)
+    if (v1[i].sec * NSecInSec + v1[i].nsec < v2[i].sec * NSecInSec + v2[i].nsec)
     {
       EXPECT_LT(v1[i], v2[i]);
-      //      printf("%f %d ", v1[i].toSec(), v1[i].sec * 1000000000ULL + v1[i].nsec);
-      //printf("vs %f %d\n", v2[i].toSec(), v2[i].sec * 1000000000ULL + v2[i].nsec);
+      //      printf("%f %d ", v1[i].toSec(), v1[i].sec * NSecInSec + v1[i].nsec);
+      //printf("vs %f %d\n", v2[i].toSec(), v2[i].sec * NSecInSec + v2[i].nsec);
       EXPECT_LE(v1[i], v2[i]);
       EXPECT_NE(v1[i], v2[i]);
     }
-    else if (v1[i].sec * 1000000000ULL + v1[i].nsec > v2[i].sec * 1000000000ULL + v2[i].nsec)
+    else if (v1[i].sec * NSecInSec + v1[i].nsec > v2[i].sec * NSecInSec + v2[i].nsec)
     {
       EXPECT_GT(v1[i], v2[i]);
       EXPECT_GE(v1[i], v2[i]);
@@ -157,6 +157,90 @@ TEST(Time, ToFromDouble)
 
   }
 
+}
+
+TEST(Time, toDouble)
+{
+  EXPECT_NEAR(Time(2, 0).toSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(Time(0, 2).toSec(), 0.000000002, 1e-12);
+
+  EXPECT_NEAR(Time(2, 0).toMSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Time(0, 2).toMSec(), 0.000002, 1e-9);
+
+  EXPECT_NEAR(Time(2, 0).toUSec(), 2000000.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2).toUSec(), 0.002, 1e-9);
+
+  EXPECT_EQ(Time(2, 0).toNSec(), 2000000000LL);
+  EXPECT_EQ(Time(0, 2 * NSecInMSec).toNSec(), 2000000LL);
+  EXPECT_EQ(Time(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(Time(0, 2).toNSec(), 2LL);
+
+  EXPECT_NEAR(WallTime(2, 0).toSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2).toSec(), 0.000000002, 1e-12);
+
+  EXPECT_NEAR(WallTime(2, 0).toMSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2).toMSec(), 0.000002, 1e-9);
+
+  EXPECT_NEAR(WallTime(2, 0).toUSec(), 2000000.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2).toUSec(), 0.002, 1e-9);
+
+  EXPECT_EQ(WallTime(2, 0).toNSec(), 2000000000LL);
+  EXPECT_EQ(WallTime(0, 2 * NSecInMSec).toNSec(), 2000000LL);
+  EXPECT_EQ(WallTime(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(WallTime(0, 2).toNSec(), 2LL);
+
+  EXPECT_NEAR(SteadyTime(2, 0).toSec(), 2.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2).toSec(), 0.000000002, 1e-12);
+
+  EXPECT_NEAR(SteadyTime(2, 0).toMSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2).toMSec(), 0.000002, 1e-9);
+
+  EXPECT_NEAR(SteadyTime(2, 0).toUSec(), 2000000.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2).toUSec(), 0.002, 1e-9);
+
+  EXPECT_EQ(SteadyTime(2, 0).toNSec(), 2000000000LL);
+  EXPECT_EQ(SteadyTime(0, 2 * NSecInMSec).toNSec(), 2000000LL);
+  EXPECT_EQ(SteadyTime(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(SteadyTime(0, 2).toNSec(), 2LL);
+}
+
+TEST(Time, construct)
+{
+  EXPECT_EQ(Time().fromSec(2.0), Time(2, 0));
+  EXPECT_EQ(Time().fromSec(2), Time(2, 0));
+  EXPECT_EQ(Time().fromMSec(2), Time(0, 2 * NSecInMSec));
+  EXPECT_EQ(Time().fromUSec(2), Time(0, 2 * NSecInUSec));
+  EXPECT_EQ(Time().fromNSec(2), Time(0, 2));
+
+  EXPECT_EQ(WallTime().fromSec(2.0), WallTime(2, 0));
+  EXPECT_EQ(WallTime().fromSec(2), WallTime(2, 0));
+  EXPECT_EQ(WallTime().fromMSec(2), WallTime(0, 2 * NSecInMSec));
+  EXPECT_EQ(WallTime().fromUSec(2), WallTime(0, 2 * NSecInUSec));
+  EXPECT_EQ(WallTime().fromNSec(2), WallTime(0, 2));
+
+  EXPECT_EQ(SteadyTime().fromSec(2.0), SteadyTime(2, 0));
+  EXPECT_EQ(SteadyTime().fromSec(2), SteadyTime(2, 0));
+  EXPECT_EQ(SteadyTime().fromMSec(2), SteadyTime(0, 2 * NSecInMSec));
+  EXPECT_EQ(SteadyTime().fromUSec(2), SteadyTime(0, 2 * NSecInUSec));
+  EXPECT_EQ(SteadyTime().fromNSec(2), SteadyTime(0, 2));
 }
 
 TEST(Time, RoundingError)
@@ -189,10 +273,10 @@ TEST(Time, OperatorPlus)
   EXPECT_EQ(r.nsec, 100100UL);
 
   t = Time(0, 0);
-  d = Duration(10, 2000003000UL);
+  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
   r = t + d;
   EXPECT_EQ(r.sec, 12UL);
-  EXPECT_EQ(r.nsec, 3000UL);
+  EXPECT_EQ(r.nsec, 3UL * NSecInUSec);
 }
 
 TEST(Time, OperatorMinus)
@@ -210,10 +294,10 @@ TEST(Time, OperatorMinus)
   EXPECT_EQ(r.nsec, 99900UL);
 
   t = Time(30, 0);
-  d = Duration(10, 2000003000UL);
+  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
   r = t - d;
   EXPECT_EQ(r.sec, 17UL);
-  EXPECT_EQ(r.nsec, 999997000ULL);
+  EXPECT_EQ(r.nsec, 999997UL * NSecInUSec);
 }
 
 TEST(Time, OperatorPlusEquals)
@@ -231,10 +315,10 @@ TEST(Time, OperatorPlusEquals)
   EXPECT_EQ(t.nsec, 100100UL);
 
   t = Time(0, 0);
-  d = Duration(10, 2000003000UL);
+  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
   t += d;
   EXPECT_EQ(t.sec, 12UL);
-  EXPECT_EQ(t.nsec, 3000UL);
+  EXPECT_EQ(t.nsec, 3UL * NSecInUSec);
 }
 
 TEST(Time, OperatorMinusEquals)
@@ -252,15 +336,15 @@ TEST(Time, OperatorMinusEquals)
   EXPECT_EQ(t.nsec, 99900UL);
 
   t = Time(30, 0);
-  d = Duration(10, 2000003000UL);
+  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
   t -= d;
   EXPECT_EQ(t.sec, 17UL);
-  EXPECT_EQ(t.nsec, 999997000ULL);
+  EXPECT_EQ(t.nsec, 999997UL * NSecInUSec);
 }
 
 TEST(Time, SecNSecConstructor)
 {
-  Time t(100, 2000003000UL);
+  Time t(100, 2UL * NSecInSec + 3UL * NSecInUSec);
   EXPECT_EQ(t.sec, 102UL);
   EXPECT_EQ(t.nsec, 3000UL);
 }
@@ -268,7 +352,7 @@ TEST(Time, SecNSecConstructor)
 TEST(Time, DontMungeStreamState)
 {
   std::ostringstream oss;
-  Time t(100, 2000003000UL);
+  Time t(100, 2UL * NSecInSec + 3UL * NSecInUSec);
   oss << std::setfill('N');
   oss << std::setw(13);
   oss << t;
@@ -315,13 +399,13 @@ TEST(Time, OperatorMinusExceptions)
   ros::Time::init();
 
   Time t1(2147483648, 0);
-  Time t2(2147483647, 999999999);
-  Time t3(2147483647, 999999998);
-  Time t4(4294967295, 999999999);
-  Time t5(4294967295, 999999998);
+  Time t2(2147483647, NSecInSec - 1);
+  Time t3(2147483647, NSecInSec - 2);
+  Time t4(4294967295, NSecInSec - 1);
+  Time t5(4294967295, NSecInSec - 2);
   Time t6(0, 1);
 
-  Duration d1(2147483647, 999999999);
+  Duration d1(2147483647, NSecInSec - 1);
   Duration d2(-2147483648, 0);
   Duration d3(-2147483648, 1);
   Duration d4(0, 1);
@@ -346,11 +430,11 @@ TEST(Time, OperatorPlusExceptions)
   ros::Time::init();
 
   Time t1(2147483648, 0);
-  Time t2(2147483647, 999999999);
-  Time t4(4294967295, 999999999);
-  Time t5(4294967295, 999999998);
+  Time t2(2147483647, NSecInSec - 1);
+  Time t4(4294967295, NSecInSec - 1);
+  Time t5(4294967295, NSecInSec - 2);
 
-  Duration d1(2147483647, 999999999);
+  Duration d1(2147483647, NSecInSec - 1);
   Duration d2(-2147483648, 1);
   Duration d3(0, 2);
   Duration d4(0, 1);
@@ -373,7 +457,7 @@ TEST(Duration, Comparitors)
 
   for (uint32_t i = 0; i < v1.size(); i++)
   {
-    if (v1[i].sec * 1000000000LL + v1[i].nsec < v2[i].sec * 1000000000LL + v2[i].nsec)
+    if (v1[i].sec * NSecInSec + v1[i].nsec < v2[i].sec * NSecInSec + v2[i].nsec)
     {
       EXPECT_LT(v1[i], v2[i]);
 //      printf("%f %lld ", v1[i].toSec(), v1[i].sec * 1000000000LL + v1[i].nsec);
@@ -381,7 +465,7 @@ TEST(Duration, Comparitors)
       EXPECT_LE(v1[i], v2[i]);
       EXPECT_NE(v1[i], v2[i]);
     }
-    else if (v1[i].sec * 1000000000LL + v1[i].nsec > v2[i].sec * 1000000000LL + v2[i].nsec)
+    else if (v1[i].sec * NSecInSec + v1[i].nsec > v2[i].sec * NSecInSec + v2[i].nsec)
     {
       EXPECT_GT(v1[i], v2[i]);
 //      printf("%f %lld ", v1[i].toSec(), v1[i].sec * 1000000000LL + v1[i].nsec);
@@ -411,23 +495,23 @@ TEST(Duration, ToFromSec)
     EXPECT_GE(ros::Duration(v1[i].toSec()).nsec, 0);
   }
 
-  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(-1LL, 500000000LL));
-  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(0, -500000000LL));
+  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(-1LL, 500LL * NSecInMSec));
+  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(0, -500LL * NSecInMSec));
 }
 
 TEST(Duration, FromNSec)
 {
   ros::Duration t;
-  t.fromNSec(-500000000LL);
+  t.fromNSec(-500LL * NSecInMSec);
   EXPECT_EQ(ros::Duration(-0.5), t);
 
-  t.fromNSec(-1500000000LL);
+  t.fromNSec(-1500LL * NSecInMSec);
   EXPECT_EQ(ros::Duration(-1.5), t);
 
-  t.fromNSec(500000000LL);
+  t.fromNSec(500LL * NSecInMSec);
   EXPECT_EQ(ros::Duration(0.5), t);
 
-  t.fromNSec(1500000000LL);
+  t.fromNSec(1500LL * NSecInMSec);
   EXPECT_EQ(ros::Duration(1.5), t);
 }
 
@@ -503,10 +587,10 @@ TEST(Duration, OperatorPlusEquals)
   EXPECT_EQ(t.nsec, 100100L);
 
   t = Duration(0, 0);
-  d = Duration(10, 2000003000L);
+  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
   t += d;
   EXPECT_EQ(t.sec, 12L);
-  EXPECT_EQ(t.nsec, 3000L);
+  EXPECT_EQ(t.nsec, 3L * NSecInUSec);
 }
 
 TEST(Duration, OperatorMinusEquals)
@@ -524,10 +608,10 @@ TEST(Duration, OperatorMinusEquals)
   EXPECT_EQ(t.nsec, 99900L);
 
   t = Duration(30, 0);
-  d = Duration(10, 2000003000L);
+  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
   t -= d;
   EXPECT_EQ(t.sec, 17L);
-  EXPECT_EQ(t.nsec, 999997000L);
+  EXPECT_EQ(t.nsec, 999997L * NSecInUSec);
 }
 
 void alarmHandler(int sig)

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -66,8 +66,8 @@ void generate_rand_times(uint32_t range, uint64_t runs, std::vector<ros::Time>& 
   values2.reserve(runs);
   for ( uint32_t i = 0; i < runs ; i++ )
   {
-    values1.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * NSecInSec/RAND_MAX)));
-    values2.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * NSecInSec/RAND_MAX)));
+    values1.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * SEC_TO_NSEC / RAND_MAX)));
+    values2.push_back(ros::Time( (rand() * range / RAND_MAX), (rand() * SEC_TO_NSEC / RAND_MAX)));
   }
 }
 
@@ -81,26 +81,26 @@ void generate_rand_durations(uint32_t range, uint64_t runs, std::vector<ros::Dur
   for ( uint32_t i = 0; i < runs ; i++ )
   {
     // positive durations
-    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
-    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
+    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * SEC_TO_NSEC / RAND_MAX)));
+    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * SEC_TO_NSEC / RAND_MAX)));
     EXPECT_GE(values1.back(), ros::Duration(0,0));
     EXPECT_GE(values2.back(), ros::Duration(0,0));
 
     // negative durations
-    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
-    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
+    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * SEC_TO_NSEC / RAND_MAX)));
+    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * SEC_TO_NSEC / RAND_MAX)));
     EXPECT_LE(values1.back(), ros::Duration(0,0));
     EXPECT_LE(values2.back(), ros::Duration(0,0));
 
     // positive and negative durations
-    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
-    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
+    values1.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * SEC_TO_NSEC / RAND_MAX)));
+    values2.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * SEC_TO_NSEC / RAND_MAX)));
     EXPECT_GE(values1.back(), ros::Duration(0,0));
     EXPECT_LE(values2.back(), ros::Duration(0,0));
 
     // negative and positive durations
-    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * NSecInSec/RAND_MAX)));
-    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * NSecInSec/RAND_MAX)));
+    values1.push_back(ros::Duration( -(rand() * range / RAND_MAX), -(rand() * SEC_TO_NSEC / RAND_MAX)));
+    values2.push_back(ros::Duration(  (rand() * range / RAND_MAX),  (rand() * SEC_TO_NSEC / RAND_MAX)));
     EXPECT_LE(values1.back(), ros::Duration(0,0));
     EXPECT_GE(values2.back(), ros::Duration(0,0));
   }
@@ -120,15 +120,15 @@ TEST(Time, Comparitors)
 
   for (uint32_t i = 0; i < v1.size(); i++)
   {
-    if (v1[i].sec * NSecInSec + v1[i].nsec < v2[i].sec * NSecInSec + v2[i].nsec)
+    if (v1[i].sec * SEC_TO_NSEC + v1[i].nsec < v2[i].sec * SEC_TO_NSEC + v2[i].nsec)
     {
       EXPECT_LT(v1[i], v2[i]);
-      //      printf("%f %d ", v1[i].toSec(), v1[i].sec * NSecInSec + v1[i].nsec);
-      //printf("vs %f %d\n", v2[i].toSec(), v2[i].sec * NSecInSec + v2[i].nsec);
+      //      printf("%f %d ", v1[i].toSec(), v1[i].sec * SEC_TO_NSEC + v1[i].nsec);
+      //printf("vs %f %d\n", v2[i].toSec(), v2[i].sec * SEC_TO_NSEC + v2[i].nsec);
       EXPECT_LE(v1[i], v2[i]);
       EXPECT_NE(v1[i], v2[i]);
     }
-    else if (v1[i].sec * NSecInSec + v1[i].nsec > v2[i].sec * NSecInSec + v2[i].nsec)
+    else if (v1[i].sec * SEC_TO_NSEC + v1[i].nsec > v2[i].sec * SEC_TO_NSEC + v2[i].nsec)
     {
       EXPECT_GT(v1[i], v2[i]);
       EXPECT_GE(v1[i], v2[i]);
@@ -162,63 +162,63 @@ TEST(Time, ToFromDouble)
 TEST(Time, toDouble)
 {
   EXPECT_NEAR(Time(2, 0).toSec(), 2.0, 1e-9);
-  EXPECT_NEAR(Time(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
-  EXPECT_NEAR(Time(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * MSEC_TO_NSEC).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * USEC_TO_NSEC).toSec(), 0.000002, 1e-9);
   EXPECT_NEAR(Time(0, 2).toSec(), 0.000000002, 1e-12);
 
   EXPECT_NEAR(Time(2, 0).toMSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(Time(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
-  EXPECT_NEAR(Time(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * MSEC_TO_NSEC).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * USEC_TO_NSEC).toMSec(), 0.002, 1e-9);
   EXPECT_NEAR(Time(0, 2).toMSec(), 0.000002, 1e-9);
 
   EXPECT_NEAR(Time(2, 0).toUSec(), 2000000.0, 1e-9);
-  EXPECT_NEAR(Time(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(Time(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * MSEC_TO_NSEC).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(Time(0, 2 * USEC_TO_NSEC).toUSec(), 2.0, 1e-9);
   EXPECT_NEAR(Time(0, 2).toUSec(), 0.002, 1e-9);
 
   EXPECT_EQ(Time(2, 0).toNSec(), 2000000000LL);
-  EXPECT_EQ(Time(0, 2 * NSecInMSec).toNSec(), 2000000LL);
-  EXPECT_EQ(Time(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(Time(0, 2 * MSEC_TO_NSEC).toNSec(), 2000000LL);
+  EXPECT_EQ(Time(0, 2 * USEC_TO_NSEC).toNSec(), 2000LL);
   EXPECT_EQ(Time(0, 2).toNSec(), 2LL);
 
   EXPECT_NEAR(WallTime(2, 0).toSec(), 2.0, 1e-9);
-  EXPECT_NEAR(WallTime(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
-  EXPECT_NEAR(WallTime(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * MSEC_TO_NSEC).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * USEC_TO_NSEC).toSec(), 0.000002, 1e-9);
   EXPECT_NEAR(WallTime(0, 2).toSec(), 0.000000002, 1e-12);
 
   EXPECT_NEAR(WallTime(2, 0).toMSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(WallTime(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
-  EXPECT_NEAR(WallTime(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * MSEC_TO_NSEC).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * USEC_TO_NSEC).toMSec(), 0.002, 1e-9);
   EXPECT_NEAR(WallTime(0, 2).toMSec(), 0.000002, 1e-9);
 
   EXPECT_NEAR(WallTime(2, 0).toUSec(), 2000000.0, 1e-9);
-  EXPECT_NEAR(WallTime(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(WallTime(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * MSEC_TO_NSEC).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(WallTime(0, 2 * USEC_TO_NSEC).toUSec(), 2.0, 1e-9);
   EXPECT_NEAR(WallTime(0, 2).toUSec(), 0.002, 1e-9);
 
   EXPECT_EQ(WallTime(2, 0).toNSec(), 2000000000LL);
-  EXPECT_EQ(WallTime(0, 2 * NSecInMSec).toNSec(), 2000000LL);
-  EXPECT_EQ(WallTime(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(WallTime(0, 2 * MSEC_TO_NSEC).toNSec(), 2000000LL);
+  EXPECT_EQ(WallTime(0, 2 * USEC_TO_NSEC).toNSec(), 2000LL);
   EXPECT_EQ(WallTime(0, 2).toNSec(), 2LL);
 
   EXPECT_NEAR(SteadyTime(2, 0).toSec(), 2.0, 1e-9);
-  EXPECT_NEAR(SteadyTime(0, 2 * NSecInMSec).toSec(), 0.002, 1e-9);
-  EXPECT_NEAR(SteadyTime(0, 2 * NSecInUSec).toSec(), 0.000002, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * MSEC_TO_NSEC).toSec(), 0.002, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * USEC_TO_NSEC).toSec(), 0.000002, 1e-9);
   EXPECT_NEAR(SteadyTime(0, 2).toSec(), 0.000000002, 1e-12);
 
   EXPECT_NEAR(SteadyTime(2, 0).toMSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(SteadyTime(0, 2 * NSecInMSec).toMSec(), 2.0, 1e-9);
-  EXPECT_NEAR(SteadyTime(0, 2 * NSecInUSec).toMSec(), 0.002, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * MSEC_TO_NSEC).toMSec(), 2.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * USEC_TO_NSEC).toMSec(), 0.002, 1e-9);
   EXPECT_NEAR(SteadyTime(0, 2).toMSec(), 0.000002, 1e-9);
 
   EXPECT_NEAR(SteadyTime(2, 0).toUSec(), 2000000.0, 1e-9);
-  EXPECT_NEAR(SteadyTime(0, 2 * NSecInMSec).toUSec(), 2000.0, 1e-9);
-  EXPECT_NEAR(SteadyTime(0, 2 * NSecInUSec).toUSec(), 2.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * MSEC_TO_NSEC).toUSec(), 2000.0, 1e-9);
+  EXPECT_NEAR(SteadyTime(0, 2 * USEC_TO_NSEC).toUSec(), 2.0, 1e-9);
   EXPECT_NEAR(SteadyTime(0, 2).toUSec(), 0.002, 1e-9);
 
   EXPECT_EQ(SteadyTime(2, 0).toNSec(), 2000000000LL);
-  EXPECT_EQ(SteadyTime(0, 2 * NSecInMSec).toNSec(), 2000000LL);
-  EXPECT_EQ(SteadyTime(0, 2 * NSecInUSec).toNSec(), 2000LL);
+  EXPECT_EQ(SteadyTime(0, 2 * MSEC_TO_NSEC).toNSec(), 2000000LL);
+  EXPECT_EQ(SteadyTime(0, 2 * USEC_TO_NSEC).toNSec(), 2000LL);
   EXPECT_EQ(SteadyTime(0, 2).toNSec(), 2LL);
 }
 
@@ -226,21 +226,39 @@ TEST(Time, construct)
 {
   EXPECT_EQ(Time().fromSec(2.0), Time(2, 0));
   EXPECT_EQ(Time().fromSec(2), Time(2, 0));
-  EXPECT_EQ(Time().fromMSec(2), Time(0, 2 * NSecInMSec));
-  EXPECT_EQ(Time().fromUSec(2), Time(0, 2 * NSecInUSec));
+  EXPECT_EQ(Time().fromMSec(2), Time(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(Time().fromUSec(2), Time(0, 2 * USEC_TO_NSEC));
   EXPECT_EQ(Time().fromNSec(2), Time(0, 2));
 
   EXPECT_EQ(WallTime().fromSec(2.0), WallTime(2, 0));
   EXPECT_EQ(WallTime().fromSec(2), WallTime(2, 0));
-  EXPECT_EQ(WallTime().fromMSec(2), WallTime(0, 2 * NSecInMSec));
-  EXPECT_EQ(WallTime().fromUSec(2), WallTime(0, 2 * NSecInUSec));
+  EXPECT_EQ(WallTime().fromMSec(2), WallTime(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(WallTime().fromUSec(2), WallTime(0, 2 * USEC_TO_NSEC));
   EXPECT_EQ(WallTime().fromNSec(2), WallTime(0, 2));
 
   EXPECT_EQ(SteadyTime().fromSec(2.0), SteadyTime(2, 0));
   EXPECT_EQ(SteadyTime().fromSec(2), SteadyTime(2, 0));
-  EXPECT_EQ(SteadyTime().fromMSec(2), SteadyTime(0, 2 * NSecInMSec));
-  EXPECT_EQ(SteadyTime().fromUSec(2), SteadyTime(0, 2 * NSecInUSec));
+  EXPECT_EQ(SteadyTime().fromMSec(2), SteadyTime(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(SteadyTime().fromUSec(2), SteadyTime(0, 2 * USEC_TO_NSEC));
   EXPECT_EQ(SteadyTime().fromNSec(2), SteadyTime(0, 2));
+
+  EXPECT_EQ(Time::seconds(2.0), Time(2, 0));
+  EXPECT_EQ(Time::seconds(2), Time(2, 0));
+  EXPECT_EQ(Time::milliseconds(2), Time(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(Time::microseconds(2), Time(0, 2 * USEC_TO_NSEC));
+  EXPECT_EQ(Time::nanoseconds(2), Time(0, 2));
+
+  EXPECT_EQ(WallTime::seconds(2.0), WallTime(2, 0));
+  EXPECT_EQ(WallTime::seconds(2), WallTime(2, 0));
+  EXPECT_EQ(WallTime::milliseconds(2), WallTime(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(WallTime::microseconds(2), WallTime(0, 2 * USEC_TO_NSEC));
+  EXPECT_EQ(WallTime::nanoseconds(2), WallTime(0, 2));
+
+  EXPECT_EQ(SteadyTime::seconds(2.0), SteadyTime(2, 0));
+  EXPECT_EQ(SteadyTime::seconds(2), SteadyTime(2, 0));
+  EXPECT_EQ(SteadyTime::milliseconds(2), SteadyTime(0, 2 * MSEC_TO_NSEC));
+  EXPECT_EQ(SteadyTime::microseconds(2), SteadyTime(0, 2 * USEC_TO_NSEC));
+  EXPECT_EQ(SteadyTime::nanoseconds(2), SteadyTime(0, 2));
 }
 
 TEST(Time, RoundingError)
@@ -273,10 +291,10 @@ TEST(Time, OperatorPlus)
   EXPECT_EQ(r.nsec, 100100UL);
 
   t = Time(0, 0);
-  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
+  d = Duration(10, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   r = t + d;
   EXPECT_EQ(r.sec, 12UL);
-  EXPECT_EQ(r.nsec, 3UL * NSecInUSec);
+  EXPECT_EQ(r.nsec, 3UL * USEC_TO_NSEC);
 }
 
 TEST(Time, OperatorMinus)
@@ -294,10 +312,10 @@ TEST(Time, OperatorMinus)
   EXPECT_EQ(r.nsec, 99900UL);
 
   t = Time(30, 0);
-  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
+  d = Duration(10, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   r = t - d;
   EXPECT_EQ(r.sec, 17UL);
-  EXPECT_EQ(r.nsec, 999997UL * NSecInUSec);
+  EXPECT_EQ(r.nsec, 999997UL * USEC_TO_NSEC);
 }
 
 TEST(Time, OperatorPlusEquals)
@@ -315,10 +333,10 @@ TEST(Time, OperatorPlusEquals)
   EXPECT_EQ(t.nsec, 100100UL);
 
   t = Time(0, 0);
-  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
+  d = Duration(10, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   t += d;
   EXPECT_EQ(t.sec, 12UL);
-  EXPECT_EQ(t.nsec, 3UL * NSecInUSec);
+  EXPECT_EQ(t.nsec, 3UL * USEC_TO_NSEC);
 }
 
 TEST(Time, OperatorMinusEquals)
@@ -336,15 +354,15 @@ TEST(Time, OperatorMinusEquals)
   EXPECT_EQ(t.nsec, 99900UL);
 
   t = Time(30, 0);
-  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
+  d = Duration(10, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   t -= d;
   EXPECT_EQ(t.sec, 17UL);
-  EXPECT_EQ(t.nsec, 999997UL * NSecInUSec);
+  EXPECT_EQ(t.nsec, 999997UL * USEC_TO_NSEC);
 }
 
 TEST(Time, SecNSecConstructor)
 {
-  Time t(100, 2UL * NSecInSec + 3UL * NSecInUSec);
+  Time t(100, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   EXPECT_EQ(t.sec, 102UL);
   EXPECT_EQ(t.nsec, 3000UL);
 }
@@ -352,7 +370,7 @@ TEST(Time, SecNSecConstructor)
 TEST(Time, DontMungeStreamState)
 {
   std::ostringstream oss;
-  Time t(100, 2UL * NSecInSec + 3UL * NSecInUSec);
+  Time t(100, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   oss << std::setfill('N');
   oss << std::setw(13);
   oss << t;
@@ -399,13 +417,13 @@ TEST(Time, OperatorMinusExceptions)
   ros::Time::init();
 
   Time t1(2147483648, 0);
-  Time t2(2147483647, NSecInSec - 1);
-  Time t3(2147483647, NSecInSec - 2);
-  Time t4(4294967295, NSecInSec - 1);
-  Time t5(4294967295, NSecInSec - 2);
+  Time t2(2147483647, SEC_TO_NSEC - 1);
+  Time t3(2147483647, SEC_TO_NSEC - 2);
+  Time t4(4294967295, SEC_TO_NSEC - 1);
+  Time t5(4294967295, SEC_TO_NSEC - 2);
   Time t6(0, 1);
 
-  Duration d1(2147483647, NSecInSec - 1);
+  Duration d1(2147483647, SEC_TO_NSEC - 1);
   Duration d2(-2147483648, 0);
   Duration d3(-2147483648, 1);
   Duration d4(0, 1);
@@ -430,11 +448,11 @@ TEST(Time, OperatorPlusExceptions)
   ros::Time::init();
 
   Time t1(2147483648, 0);
-  Time t2(2147483647, NSecInSec - 1);
-  Time t4(4294967295, NSecInSec - 1);
-  Time t5(4294967295, NSecInSec - 2);
+  Time t2(2147483647, SEC_TO_NSEC - 1);
+  Time t4(4294967295, SEC_TO_NSEC - 1);
+  Time t5(4294967295, SEC_TO_NSEC - 2);
 
-  Duration d1(2147483647, NSecInSec - 1);
+  Duration d1(2147483647, SEC_TO_NSEC - 1);
   Duration d2(-2147483648, 1);
   Duration d3(0, 2);
   Duration d4(0, 1);
@@ -457,7 +475,7 @@ TEST(Duration, Comparitors)
 
   for (uint32_t i = 0; i < v1.size(); i++)
   {
-    if (v1[i].sec * NSecInSec + v1[i].nsec < v2[i].sec * NSecInSec + v2[i].nsec)
+    if (v1[i].sec * SEC_TO_NSEC + v1[i].nsec < v2[i].sec * SEC_TO_NSEC + v2[i].nsec)
     {
       EXPECT_LT(v1[i], v2[i]);
 //      printf("%f %lld ", v1[i].toSec(), v1[i].sec * 1000000000LL + v1[i].nsec);
@@ -465,7 +483,7 @@ TEST(Duration, Comparitors)
       EXPECT_LE(v1[i], v2[i]);
       EXPECT_NE(v1[i], v2[i]);
     }
-    else if (v1[i].sec * NSecInSec + v1[i].nsec > v2[i].sec * NSecInSec + v2[i].nsec)
+    else if (v1[i].sec * SEC_TO_NSEC + v1[i].nsec > v2[i].sec * SEC_TO_NSEC + v2[i].nsec)
     {
       EXPECT_GT(v1[i], v2[i]);
 //      printf("%f %lld ", v1[i].toSec(), v1[i].sec * 1000000000LL + v1[i].nsec);
@@ -495,23 +513,23 @@ TEST(Duration, ToFromSec)
     EXPECT_GE(ros::Duration(v1[i].toSec()).nsec, 0);
   }
 
-  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(-1LL, 500LL * NSecInMSec));
-  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(0, -500LL * NSecInMSec));
+  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(-1LL, 500LL * MSEC_TO_NSEC));
+  EXPECT_EQ(ros::Duration(-0.5), ros::Duration(0, -500LL * MSEC_TO_NSEC));
 }
 
 TEST(Duration, FromNSec)
 {
   ros::Duration t;
-  t.fromNSec(-500LL * NSecInMSec);
+  t.fromNSec(-500LL * MSEC_TO_NSEC);
   EXPECT_EQ(ros::Duration(-0.5), t);
 
-  t.fromNSec(-1500LL * NSecInMSec);
+  t.fromNSec(-1500LL * MSEC_TO_NSEC);
   EXPECT_EQ(ros::Duration(-1.5), t);
 
-  t.fromNSec(500LL * NSecInMSec);
+  t.fromNSec(500LL * MSEC_TO_NSEC);
   EXPECT_EQ(ros::Duration(0.5), t);
 
-  t.fromNSec(1500LL * NSecInMSec);
+  t.fromNSec(1500LL * MSEC_TO_NSEC);
   EXPECT_EQ(ros::Duration(1.5), t);
 }
 
@@ -587,10 +605,10 @@ TEST(Duration, OperatorPlusEquals)
   EXPECT_EQ(t.nsec, 100100L);
 
   t = Duration(0, 0);
-  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
+  d = Duration(10, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   t += d;
   EXPECT_EQ(t.sec, 12L);
-  EXPECT_EQ(t.nsec, 3L * NSecInUSec);
+  EXPECT_EQ(t.nsec, 3L * USEC_TO_NSEC);
 }
 
 TEST(Duration, OperatorMinusEquals)
@@ -608,10 +626,10 @@ TEST(Duration, OperatorMinusEquals)
   EXPECT_EQ(t.nsec, 99900L);
 
   t = Duration(30, 0);
-  d = Duration(10, 2UL * NSecInSec + 3UL * NSecInUSec);
+  d = Duration(10, 2UL * SEC_TO_NSEC + 3UL * USEC_TO_NSEC);
   t -= d;
   EXPECT_EQ(t.sec, 17L);
-  EXPECT_EQ(t.nsec, 999997L * NSecInUSec);
+  EXPECT_EQ(t.nsec, 999997L * USEC_TO_NSEC);
 }
 
 void alarmHandler(int sig)


### PR DESCRIPTION
Closes #114.

I've added constants that help converting nano-/micro-/milli-seconds and seconds between each other. The conversions are defined only for the cases where precision is not lost ("bigger" units to "smaller" units). The other direction has to be done via division, which should itself be a warning sign that precision might be lost (a concern of @tfoote).

I'm not sure about the names, whether they should be all upper-case, or if the chosen names like 'NSecInUSec' are okay. Also, I've put the constants directly in the `ros` namespace - that's mainly for convenience and to make typing of these constants shorter. They could be implemented as static members of `DurationBase` and `TimeBase`, but that seems weird, as that gives you access to the same constant via five different base classnames...

I'd also find a few more time-related things useful, and although they're not directly related to this PR, it might make sense to add them. Just let me know and I can add them. Or I can post them as separate PRs.

1. Provide static constants `Time::ZERO`, `Duration::ZERO` etc. And for `TimeBase`-derived classes, maybe also `Time::UNINITIALIZED` (which would be the same as zero).
1. Provide static factories for creating the time/duration objects from numeric values. Right now, there is `Time::fromBoost()` which goes in the same direction. Also, constructors can be seen as a kind of static factories from either a double (seconds), or a tuple of ints (seconds, nanoseconds). For all other cases, you first have to create an instance with a dummy value and then call the `from*` function on it. To provide a unified API, I'd suggest adding static methods like `Time::fromSec(double)`, `Time::fromMSec(uint64_t)`, `Time::fromUSec(uint64_t)` and `Time::fromNSec(uint64_t)`. But these names are already "taken" by non-static functions, so they'd have to use different names. As an example, I'd like names `Time::milliseconds(uint64_t)`, `Time::millisec(uint64_t)` or `Time::msec(uint64_t)`. And I'm undecided whether to also add the grammatically incorrect `Time::milisec()` just for the case somebody doesn't know there are two Ls. But if this variant were missing, he'd get a compile error, and at least GCC would probably directly tell him the name of the correct function, so maybe this "convenience" function is not needed in the end.
1. The least related, I'm always missing a `toString()` function that would return the exact string that's printed using the `ostream<<` operator. I know that there's a straightforward way via stringstream, but it's unnecessarily slow (see e.g. https://github.com/ros/geometry2/pull/470).