### PR TITLE
rostime: Added useful time and duration constants.

### DIFF
--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -98,8 +98,6 @@ public:
   static const T MIN; //!< Minimum representable duration (negative)
   static const T MAX; //!< Maximum representable duration
   static const T ZERO; //!< Zero duration
-  static const T YEAR; //!< One year duration (Gregorian year of 365.2425 days)
-  static const T WEEK; //!< One week duration
   static const T DAY; //!< One day duration
   static const T HOUR; //!< One hour duration
   static const T MINUTE; //!< One minute duration
@@ -141,8 +139,6 @@ extern ROSTIME_DECL const Duration DURATION_MIN;
 template<> const Duration DurationBase<Duration>::MAX;
 template<> const Duration DurationBase<Duration>::MIN;
 template<> const Duration DurationBase<Duration>::ZERO;
-template<> const Duration DurationBase<Duration>::YEAR;
-template<> const Duration DurationBase<Duration>::WEEK;
 template<> const Duration DurationBase<Duration>::DAY;
 template<> const Duration DurationBase<Duration>::HOUR;
 template<> const Duration DurationBase<Duration>::MINUTE;
@@ -179,8 +175,6 @@ public:
 template<> const WallDuration DurationBase<WallDuration>::MAX;
 template<> const WallDuration DurationBase<WallDuration>::MIN;
 template<> const WallDuration DurationBase<WallDuration>::ZERO;
-template<> const WallDuration DurationBase<WallDuration>::YEAR;
-template<> const WallDuration DurationBase<WallDuration>::WEEK;
 template<> const WallDuration DurationBase<WallDuration>::DAY;
 template<> const WallDuration DurationBase<WallDuration>::HOUR;
 template<> const WallDuration DurationBase<WallDuration>::MINUTE;

--- a/rostime/include/ros/duration.h
+++ b/rostime/include/ros/duration.h
@@ -95,6 +95,18 @@ public:
   T& fromNSec(int64_t t);
   bool isZero() const;
   boost::posix_time::time_duration toBoost() const;
+  static const T MIN; //!< Minimum representable duration (negative)
+  static const T MAX; //!< Maximum representable duration
+  static const T ZERO; //!< Zero duration
+  static const T YEAR; //!< One year duration (Gregorian year of 365.2425 days)
+  static const T WEEK; //!< One week duration
+  static const T DAY; //!< One day duration
+  static const T HOUR; //!< One hour duration
+  static const T MINUTE; //!< One minute duration
+  static const T SECOND; //!< One second duration
+  static const T MILLISECOND; //!< One millisecond duration
+  static const T MICROSECOND; //!< One microsecond duration
+  static const T NANOSECOND; //!< One nanosecond duration
 };
 
 class Rate;
@@ -126,6 +138,18 @@ public:
 
 extern ROSTIME_DECL const Duration DURATION_MAX;
 extern ROSTIME_DECL const Duration DURATION_MIN;
+template<> const Duration DurationBase<Duration>::MAX;
+template<> const Duration DurationBase<Duration>::MIN;
+template<> const Duration DurationBase<Duration>::ZERO;
+template<> const Duration DurationBase<Duration>::YEAR;
+template<> const Duration DurationBase<Duration>::WEEK;
+template<> const Duration DurationBase<Duration>::DAY;
+template<> const Duration DurationBase<Duration>::HOUR;
+template<> const Duration DurationBase<Duration>::MINUTE;
+template<> const Duration DurationBase<Duration>::SECOND;
+template<> const Duration DurationBase<Duration>::MILLISECOND;
+template<> const Duration DurationBase<Duration>::MICROSECOND;
+template<> const Duration DurationBase<Duration>::NANOSECOND;
 
 /**
  * \brief Duration representation for use with the WallTime class.
@@ -151,6 +175,19 @@ public:
    */
   bool sleep() const;
 };
+
+template<> const WallDuration DurationBase<WallDuration>::MAX;
+template<> const WallDuration DurationBase<WallDuration>::MIN;
+template<> const WallDuration DurationBase<WallDuration>::ZERO;
+template<> const WallDuration DurationBase<WallDuration>::YEAR;
+template<> const WallDuration DurationBase<WallDuration>::WEEK;
+template<> const WallDuration DurationBase<WallDuration>::DAY;
+template<> const WallDuration DurationBase<WallDuration>::HOUR;
+template<> const WallDuration DurationBase<WallDuration>::MINUTE;
+template<> const WallDuration DurationBase<WallDuration>::SECOND;
+template<> const WallDuration DurationBase<WallDuration>::MILLISECOND;
+template<> const WallDuration DurationBase<WallDuration>::MICROSECOND;
+template<> const WallDuration DurationBase<WallDuration>::NANOSECOND;
 
 ROSTIME_DECL std::ostream &operator <<(std::ostream &os, const Duration &rhs);
 ROSTIME_DECL std::ostream &operator <<(std::ostream &os, const WallDuration &rhs);

--- a/rostime/include/ros/time.h
+++ b/rostime/include/ros/time.h
@@ -160,6 +160,10 @@ namespace ros
     inline bool is_zero() const { return isZero(); }
     boost::posix_time::ptime toBoost() const;
 
+    static const T MIN; //!< Minimum representable time
+    static const T MAX; //!< Maximum representable time
+    static const T ZERO; //!< Zero (invalid) time
+    static const T UNINITIALIZED; //!< Uninitialized time
   };
 
   /**
@@ -217,6 +221,10 @@ namespace ros
 
   extern ROSTIME_DECL const Time TIME_MAX;
   extern ROSTIME_DECL const Time TIME_MIN;
+  template<> const Time TimeBase<Time, Duration>::MAX;
+  template<> const Time TimeBase<Time, Duration>::MIN;
+  template<> const Time TimeBase<Time, Duration>::ZERO;
+  template<> const Time TimeBase<Time, Duration>::UNINITIALIZED;
 
   /**
    * \brief Time representation.  Always wall-clock time.
@@ -249,7 +257,12 @@ namespace ros
 
     static bool isSystemTime() { return true; }
   };
-
+  
+  template<> const WallTime TimeBase<WallTime, WallDuration>::MAX;
+  template<> const WallTime TimeBase<WallTime, WallDuration>::MIN;
+  template<> const WallTime TimeBase<WallTime, WallDuration>::ZERO;
+  template<> const WallTime TimeBase<WallTime, WallDuration>::UNINITIALIZED;
+  
   /**
    * \brief Time representation.  Always steady-clock time.
    *
@@ -283,6 +296,11 @@ namespace ros
 
       static bool isSystemTime() { return true; }
   };
+
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::MAX;
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::MIN;
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::ZERO;
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::UNINITIALIZED;
 
   ROSTIME_DECL std::ostream &operator <<(std::ostream &os, const Time &rhs);
   ROSTIME_DECL std::ostream &operator <<(std::ostream &os, const WallTime &rhs);

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -93,15 +93,10 @@ namespace ros
   template<> const Duration DurationBase<Duration>::MINUTE = Duration(60, 0);
   template<> const Duration DurationBase<Duration>::HOUR = Duration(60 * 60, 0);
   template<> const Duration DurationBase<Duration>::DAY = Duration(60 * 60 * 24, 0);
-  template<> const Duration DurationBase<Duration>::WEEK = Duration(60 * 60 * 24 * 7, 0);
-  // 97 leap years and 303 common years in each 400 years cycle, ((97 * 366) + (303 * 365)) / 400 = 365.2425 exactly
-  template<> const Duration DurationBase<Duration>::YEAR = Duration(static_cast<int32_t>(60 * 60 * 24 * 365.2425), 0);
 
   template<> const WallDuration DurationBase<WallDuration>::MAX = WallDuration(Duration::MAX.sec, Duration::MAX.nsec);
   template<> const WallDuration DurationBase<WallDuration>::MIN = WallDuration(Duration::MIN.sec, Duration::MIN.nsec);
   template<> const WallDuration DurationBase<WallDuration>::ZERO = WallDuration(Duration::ZERO.sec, Duration::ZERO.nsec);
-  template<> const WallDuration DurationBase<WallDuration>::YEAR = WallDuration(Duration::YEAR.sec, Duration::YEAR.nsec);
-  template<> const WallDuration DurationBase<WallDuration>::WEEK = WallDuration(Duration::WEEK.sec, Duration::WEEK.nsec);
   template<> const WallDuration DurationBase<WallDuration>::DAY = WallDuration(Duration::DAY.sec, Duration::DAY.nsec);
   template<> const WallDuration DurationBase<WallDuration>::HOUR = WallDuration(Duration::HOUR.sec, Duration::HOUR.nsec);
   template<> const WallDuration DurationBase<WallDuration>::MINUTE = WallDuration(Duration::MINUTE.sec, Duration::MINUTE.nsec);

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -83,8 +83,50 @@ namespace ros
   const Duration DURATION_MAX(std::numeric_limits<int32_t>::max(), 999999999);
   const Duration DURATION_MIN(std::numeric_limits<int32_t>::min(), 0);
 
+  template<> const Duration DurationBase<Duration>::MAX = DURATION_MAX;
+  template<> const Duration DurationBase<Duration>::MIN = DURATION_MIN;
+  template<> const Duration DurationBase<Duration>::ZERO = Duration(0, 0);
+  template<> const Duration DurationBase<Duration>::NANOSECOND = Duration(0, 1);
+  template<> const Duration DurationBase<Duration>::MICROSECOND = Duration(0, 1000);
+  template<> const Duration DurationBase<Duration>::MILLISECOND = Duration(0, 1000000);
+  template<> const Duration DurationBase<Duration>::SECOND = Duration(1, 0);
+  template<> const Duration DurationBase<Duration>::MINUTE = Duration(60, 0);
+  template<> const Duration DurationBase<Duration>::HOUR = Duration(60 * 60, 0);
+  template<> const Duration DurationBase<Duration>::DAY = Duration(60 * 60 * 24, 0);
+  template<> const Duration DurationBase<Duration>::WEEK = Duration(60 * 60 * 24 * 7, 0);
+  // 97 leap years and 303 common years in each 400 years cycle, ((97 * 366) + (303 * 365)) / 400 = 365.2425 exactly
+  template<> const Duration DurationBase<Duration>::YEAR = Duration(static_cast<int32_t>(60 * 60 * 24 * 365.2425), 0);
+
+  template<> const WallDuration DurationBase<WallDuration>::MAX = WallDuration(Duration::MAX.sec, Duration::MAX.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::MIN = WallDuration(Duration::MIN.sec, Duration::MIN.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::ZERO = WallDuration(Duration::ZERO.sec, Duration::ZERO.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::YEAR = WallDuration(Duration::YEAR.sec, Duration::YEAR.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::WEEK = WallDuration(Duration::WEEK.sec, Duration::WEEK.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::DAY = WallDuration(Duration::DAY.sec, Duration::DAY.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::HOUR = WallDuration(Duration::HOUR.sec, Duration::HOUR.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::MINUTE = WallDuration(Duration::MINUTE.sec, Duration::MINUTE.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::SECOND = WallDuration(Duration::SECOND.sec, Duration::SECOND.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::MILLISECOND = WallDuration(Duration::MILLISECOND.sec, Duration::MILLISECOND.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::MICROSECOND = WallDuration(Duration::MICROSECOND.sec, Duration::MICROSECOND.nsec);
+  template<> const WallDuration DurationBase<WallDuration>::NANOSECOND = WallDuration(Duration::NANOSECOND.sec, Duration::NANOSECOND.nsec);
+
   const Time TIME_MAX(std::numeric_limits<uint32_t>::max(), 999999999);
   const Time TIME_MIN(0, 1);
+
+  template<> const Time TimeBase<Time, Duration>::MAX = TIME_MAX;
+  template<> const Time TimeBase<Time, Duration>::MIN = TIME_MIN;
+  template<> const Time TimeBase<Time, Duration>::ZERO = Time(0, 0);
+  template<> const Time TimeBase<Time, Duration>::UNINITIALIZED = Time::ZERO;
+
+  template<> const WallTime TimeBase<WallTime, WallDuration>::MAX = WallTime(Time::MAX.sec, Time::MAX.nsec);
+  template<> const WallTime TimeBase<WallTime, WallDuration>::MIN = WallTime(Time::MIN.sec, Time::MIN.nsec);
+  template<> const WallTime TimeBase<WallTime, WallDuration>::ZERO = WallTime(Time::ZERO.sec, Time::ZERO.nsec);
+  template<> const WallTime TimeBase<WallTime, WallDuration>::UNINITIALIZED = WallTime(Time::UNINITIALIZED.sec, Time::UNINITIALIZED.nsec);
+
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::MAX = SteadyTime(Time::MAX.sec, Time::MAX.nsec);
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::MIN = SteadyTime(Time::MIN.sec, Time::MIN.nsec);
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::ZERO = SteadyTime(Time::ZERO.sec, Time::ZERO.nsec);
+  template<> const SteadyTime TimeBase<SteadyTime, WallDuration>::UNINITIALIZED = SteadyTime(Time::UNINITIALIZED.sec, Time::UNINITIALIZED.nsec);
 
   // This is declared here because it's set from the Time class but read from
   // the Duration class, and need not be exported to users of either.

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -363,6 +363,36 @@ TEST(Time, OperatorPlusExceptions)
   EXPECT_THROW(t5 + d3, std::runtime_error);
 }
 
+TEST(Time, Constants)
+{
+  EXPECT_EQ(Time::MAX.sec, static_cast<uint32_t>(-1));
+  EXPECT_EQ(Time::MAX.nsec, 999999999);
+  EXPECT_EQ(Time::MIN.sec, 0);
+  EXPECT_EQ(Time::MIN.nsec, 1);
+  EXPECT_EQ(Time::ZERO.sec, 0);
+  EXPECT_EQ(Time::ZERO.nsec, 0);
+  EXPECT_EQ(Time::UNINITIALIZED.sec, 0);
+  EXPECT_EQ(Time::UNINITIALIZED.nsec, 0);
+
+  EXPECT_EQ(WallTime::MAX.sec, static_cast<uint32_t>(-1));
+  EXPECT_EQ(WallTime::MAX.nsec, 999999999);
+  EXPECT_EQ(WallTime::MIN.sec, 0);
+  EXPECT_EQ(WallTime::MIN.nsec, 1);
+  EXPECT_EQ(WallTime::ZERO.sec, 0);
+  EXPECT_EQ(WallTime::ZERO.nsec, 0);
+  EXPECT_EQ(WallTime::UNINITIALIZED.sec, 0);
+  EXPECT_EQ(WallTime::UNINITIALIZED.nsec, 0);
+
+  EXPECT_EQ(SteadyTime::MAX.sec, static_cast<uint32_t>(-1));
+  EXPECT_EQ(SteadyTime::MAX.nsec, 999999999);
+  EXPECT_EQ(SteadyTime::MIN.sec, 0);
+  EXPECT_EQ(SteadyTime::MIN.nsec, 1);
+  EXPECT_EQ(SteadyTime::ZERO.sec, 0);
+  EXPECT_EQ(SteadyTime::ZERO.nsec, 0);
+  EXPECT_EQ(SteadyTime::UNINITIALIZED.sec, 0);
+  EXPECT_EQ(SteadyTime::UNINITIALIZED.nsec, 0);
+}
+
 /************************************* Duration Tests *****************/
 
 TEST(Duration, Comparitors)
@@ -549,6 +579,59 @@ TEST(Duration, sleepWithSignal)
 
   ASSERT_GT(end - start, d);
   ASSERT_TRUE(rc);
+}
+
+TEST(Duration, Constants)
+{
+  EXPECT_EQ(Duration::MAX.sec, std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(Duration::MAX.nsec, 999999999);
+  EXPECT_EQ(Duration::MIN.sec, std::numeric_limits<int32_t>::min());
+  EXPECT_EQ(Duration::MIN.nsec, 0);
+  EXPECT_EQ(Duration::ZERO.sec, 0);
+  EXPECT_EQ(Duration::ZERO.nsec, 0);
+  EXPECT_EQ(Duration::NANOSECOND.sec, 0);
+  EXPECT_EQ(Duration::NANOSECOND.nsec, 1);
+  EXPECT_EQ(Duration::MICROSECOND.sec, 0);
+  EXPECT_EQ(Duration::MICROSECOND.nsec, 1000);
+  EXPECT_EQ(Duration::MILLISECOND.sec, 0);
+  EXPECT_EQ(Duration::MILLISECOND.nsec, 1000000);
+  EXPECT_EQ(Duration::SECOND.sec, 1);
+  EXPECT_EQ(Duration::SECOND.nsec, 0);
+  EXPECT_EQ(Duration::MINUTE.sec, 60);
+  EXPECT_EQ(Duration::MINUTE.nsec, 0);
+  EXPECT_EQ(Duration::HOUR.sec, 60 * 60);
+  EXPECT_EQ(Duration::HOUR.nsec, 0);
+  EXPECT_EQ(Duration::DAY.sec, 60 * 60 * 24);
+  EXPECT_EQ(Duration::DAY.nsec, 0);
+  EXPECT_EQ(Duration::WEEK.sec, 60 * 60 * 24 * 7);
+  EXPECT_EQ(Duration::WEEK.nsec, 0);
+  EXPECT_EQ(Duration::YEAR.sec, static_cast<int32_t>(60 * 60 * 24 * 365.2425));
+  EXPECT_EQ(Duration::YEAR.nsec, 0);
+
+  EXPECT_EQ(WallDuration::MAX.sec, std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(WallDuration::MAX.nsec, 999999999);
+  EXPECT_EQ(WallDuration::MIN.sec, std::numeric_limits<int32_t>::min());
+  EXPECT_EQ(WallDuration::MIN.nsec, 0);
+  EXPECT_EQ(WallDuration::ZERO.sec, 0);
+  EXPECT_EQ(WallDuration::ZERO.nsec, 0);
+  EXPECT_EQ(WallDuration::NANOSECOND.sec, 0);
+  EXPECT_EQ(WallDuration::NANOSECOND.nsec, 1);
+  EXPECT_EQ(WallDuration::MICROSECOND.sec, 0);
+  EXPECT_EQ(WallDuration::MICROSECOND.nsec, 1000);
+  EXPECT_EQ(WallDuration::MILLISECOND.sec, 0);
+  EXPECT_EQ(WallDuration::MILLISECOND.nsec, 1000000);
+  EXPECT_EQ(WallDuration::SECOND.sec, 1);
+  EXPECT_EQ(WallDuration::SECOND.nsec, 0);
+  EXPECT_EQ(WallDuration::MINUTE.sec, 60);
+  EXPECT_EQ(WallDuration::MINUTE.nsec, 0);
+  EXPECT_EQ(WallDuration::HOUR.sec, 60 * 60);
+  EXPECT_EQ(WallDuration::HOUR.nsec, 0);
+  EXPECT_EQ(WallDuration::DAY.sec, 60 * 60 * 24);
+  EXPECT_EQ(WallDuration::DAY.nsec, 0);
+  EXPECT_EQ(WallDuration::WEEK.sec, 60 * 60 * 24 * 7);
+  EXPECT_EQ(WallDuration::WEEK.nsec, 0);
+  EXPECT_EQ(WallDuration::YEAR.sec, static_cast<int32_t>(60 * 60 * 24 * 365.2425));
+  EXPECT_EQ(WallDuration::YEAR.nsec, 0);
 }
 
 TEST(Rate, constructFromDuration){

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -603,10 +603,6 @@ TEST(Duration, Constants)
   EXPECT_EQ(Duration::HOUR.nsec, 0);
   EXPECT_EQ(Duration::DAY.sec, 60 * 60 * 24);
   EXPECT_EQ(Duration::DAY.nsec, 0);
-  EXPECT_EQ(Duration::WEEK.sec, 60 * 60 * 24 * 7);
-  EXPECT_EQ(Duration::WEEK.nsec, 0);
-  EXPECT_EQ(Duration::YEAR.sec, static_cast<int32_t>(60 * 60 * 24 * 365.2425));
-  EXPECT_EQ(Duration::YEAR.nsec, 0);
 
   EXPECT_EQ(WallDuration::MAX.sec, std::numeric_limits<int32_t>::max());
   EXPECT_EQ(WallDuration::MAX.nsec, 999999999);
@@ -628,10 +624,6 @@ TEST(Duration, Constants)
   EXPECT_EQ(WallDuration::HOUR.nsec, 0);
   EXPECT_EQ(WallDuration::DAY.sec, 60 * 60 * 24);
   EXPECT_EQ(WallDuration::DAY.nsec, 0);
-  EXPECT_EQ(WallDuration::WEEK.sec, 60 * 60 * 24 * 7);
-  EXPECT_EQ(WallDuration::WEEK.nsec, 0);
-  EXPECT_EQ(WallDuration::YEAR.sec, static_cast<int32_t>(60 * 60 * 24 * 365.2425));
-  EXPECT_EQ(WallDuration::YEAR.nsec, 0);
 }
 
 TEST(Rate, constructFromDuration){


### PR DESCRIPTION
For `Time`, `WallTime` and `SteadyTime`, I added static constants `MIN`, `MAX`, `ZERO` and `UNINITIALIZED`.

For `Duration` and `WallDuration`, I added static constants `MIN`, `MAX`, `ZERO`, `NANOSECOND`, `MICROSECOND`, `MILLISECOND`, `SECOND`, `MINUTE`, `HOUR`, `DAY`, `WEEK` and `YEAR`.

In the header files, I added explicit specialization declarations for each of the constants. The build and tests succeeded even without these definitions, but clang suggested to add them and I did so.

I'm not sure if `YEAR` should represent 365 days or 365.2425. I vouch for the latter as it yields smaller errors if you count with large durations (e.g. in 10 years, the 365-day year gives you 2 day error, whereas 365.2425 day has error somewhere around half a day).

These constants are mainly syntactic sugar, but I imagine they could become used over time when people know about them.