### PR TITLE
Fixed handling of infinite or >int64 doubles in Time and Duration constructors

### DIFF
--- a/rostime/include/ros/impl/duration.h
+++ b/rostime/include/ros/impl/duration.h
@@ -34,6 +34,9 @@
 #ifndef ROSTIME_IMPL_DURATION_H_INCLUDED
 #define ROSTIME_IMPL_DURATION_H_INCLUDED
 
+#include <cmath>
+#include <limits>
+
 #include <ros/duration.h>
 #include <ros/rate.h>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
@@ -53,6 +56,12 @@ namespace ros {
   template<class T>
   T& DurationBase<T>::fromSec(double d)
   {
+    if (!std::isfinite(d))
+      throw std::runtime_error("Duration has to be finite.");
+    constexpr double minInt64AsDouble = static_cast<double>(std::numeric_limits<int64_t>::min());
+    constexpr double maxInt64AsDouble = static_cast<double>(std::numeric_limits<int64_t>::max());
+    if (d <= minInt64AsDouble || d >= maxInt64AsDouble)
+      throw std::runtime_error("Duration is out of 64-bit integer range");
     int64_t sec64 = static_cast<int64_t>(floor(d));
     if (sec64 < std::numeric_limits<int32_t>::min() || sec64 > std::numeric_limits<int32_t>::max())
       throw std::runtime_error("Duration is out of dual 32-bit range");

--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -75,8 +75,15 @@ namespace ros
 
   template<class T, class D>
   T& TimeBase<T, D>::fromSec(double t) {
+      if (t < 0)
+        throw std::runtime_error("Time cannot be negative.");
+      if (!std::isfinite(t))
+        throw std::runtime_error("Time has to be finite.");
+      constexpr double maxInt64AsDouble = static_cast<double>(std::numeric_limits<int64_t>::max());
+      if (t >= maxInt64AsDouble)
+        throw std::runtime_error("Time is out of 64-bit integer range");
       int64_t sec64 = static_cast<int64_t>(floor(t));
-      if (sec64 < 0 || sec64 > std::numeric_limits<uint32_t>::max())
+      if (sec64 > std::numeric_limits<uint32_t>::max())
         throw std::runtime_error("Time is out of dual 32-bit range");
       sec = static_cast<uint32_t>(sec64);
       nsec = static_cast<uint32_t>(boost::math::round((t-sec) * 1e9));

--- a/rostime/include/ros/impl/time.h
+++ b/rostime/include/ros/impl/time.h
@@ -42,6 +42,7 @@
 #include <ros/platform.h>
 #include <iostream>
 #include <cmath>
+#include <limits>
 #include <ros/exception.h>
 #include <ros/time.h>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/rostime/test/duration.cpp
+++ b/rostime/test/duration.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <limits>
+
 #include <gtest/gtest.h>
 #include <ros/duration.h>
 #include <ros/time.h>
@@ -52,7 +54,7 @@ TEST(Duration, castFromDoubleExceptions)
 {
   ros::Time::init();
 
-  Duration d1, d2, d3, d4;
+  Duration d1, d2, d3, d4, d5, d6, d7, d8, d9;
   // Valid values to cast, must not throw exceptions
   EXPECT_NO_THROW(d1.fromSec(-2147483648.0));
   EXPECT_NO_THROW(d2.fromSec(-2147483647.999999));
@@ -64,6 +66,12 @@ TEST(Duration, castFromDoubleExceptions)
   EXPECT_THROW(d2.fromSec(6442450943.0), std::runtime_error);  // It's 2^31 - 1 + 2^32, and it could pass the test.
   EXPECT_THROW(d3.fromSec(-2147483648.001), std::runtime_error);
   EXPECT_THROW(d4.fromSec(-6442450943.0), std::runtime_error);
+  EXPECT_THROW(d5.fromSec(std::numeric_limits<double>::infinity()), std::runtime_error);
+  EXPECT_THROW(d6.fromSec(-std::numeric_limits<double>::infinity()), std::runtime_error);
+  EXPECT_THROW(d7.fromSec(std::numeric_limits<double>::quiet_NaN()), std::runtime_error);
+  // max int64 value is 9223372036854775807
+  EXPECT_THROW(d8.fromSec(9223372036854775808.0), std::runtime_error); 
+  EXPECT_THROW(d9.fromSec(-9223372036854775809.0), std::runtime_error);
 }
 
 TEST(Duration, castFromInt64Exceptions)

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <limits>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/rostime/test/time.cpp
+++ b/rostime/test/time.cpp
@@ -298,7 +298,7 @@ TEST(Time, CastFromDoubleExceptions)
 {
   ros::Time::init();
 
-  Time t1, t2, t3;
+  Time t1, t2, t3, t4, t5, t6, t7, t8;
   // Valid values to cast, must not throw exceptions
   EXPECT_NO_THROW(t1.fromSec(4294967295.0));
   EXPECT_NO_THROW(t2.fromSec(4294967295.999));
@@ -308,6 +308,12 @@ TEST(Time, CastFromDoubleExceptions)
   EXPECT_THROW(t1.fromSec(4294967296.0), std::runtime_error);
   EXPECT_THROW(t2.fromSec(-0.0001), std::runtime_error);
   EXPECT_THROW(t3.fromSec(-4294967296.0), std::runtime_error);
+  EXPECT_THROW(t4.fromSec(std::numeric_limits<double>::infinity()), std::runtime_error);
+  EXPECT_THROW(t5.fromSec(-std::numeric_limits<double>::infinity()), std::runtime_error);
+  EXPECT_THROW(t6.fromSec(std::numeric_limits<double>::quiet_NaN()), std::runtime_error);
+  // max int64 value is 9223372036854775807
+  EXPECT_THROW(t7.fromSec(9223372036854775808.0), std::runtime_error);
+  EXPECT_THROW(t8.fromSec(-9223372036854775809.0), std::runtime_error);
 }
 
 TEST(Time, OperatorMinusExceptions)
@@ -557,6 +563,19 @@ TEST(Rate, constructFromDuration){
   EXPECT_EQ(r.expectedCycleTime(), d);
 }
 
+TEST(Rate, constructFromDouble){
+  Rate r(0.5);
+  EXPECT_EQ(r.expectedCycleTime(), ros::Duration(2, 0));
+  
+  Rate r2(-0.5);
+  EXPECT_EQ(r2.expectedCycleTime(), ros::Duration(-2, 0));
+  
+  Rate r3(std::numeric_limits<double>::infinity());
+  EXPECT_EQ(r3.expectedCycleTime(), ros::Duration(0, 0));
+
+  EXPECT_THROW(Rate(0.0), std::runtime_error);
+}
+
 TEST(Rate, sleep_return_value_true){
   Rate r(Duration(0.2));
   Duration(r.expectedCycleTime() * 0.5).sleep();
@@ -574,6 +593,19 @@ TEST(WallRate, constructFromDuration){
   WallRate r(d);
   WallDuration wd(4, 0);
   EXPECT_EQ(r.expectedCycleTime(), wd);
+}
+
+TEST(WallRate, constructFromDouble){
+  WallRate r(0.5);
+  EXPECT_EQ(r.expectedCycleTime(), ros::WallDuration(2, 0));
+
+  WallRate r2(-0.5);
+  EXPECT_EQ(r2.expectedCycleTime(), ros::WallDuration(-2, 0));
+
+  WallRate r3(std::numeric_limits<double>::infinity());
+  EXPECT_EQ(r3.expectedCycleTime(), ros::WallDuration(0, 0));
+
+  EXPECT_THROW(WallRate(0.0), std::runtime_error);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixed handling of infinite or >int64 doubles in Time and Duration constructors.

Also added tests for Rate(double) constructor, verified Rate(inf) works and Rate(0) does not.

Fixes #105.