### PR TITLE
Fixed wrong serialization of messages on ARM with GCC 9.3 and -O3 optimizations

### DIFF
--- a/roscpp_serialization/include/ros/serialization.h
+++ b/roscpp_serialization/include/ros/serialization.h
@@ -164,11 +164,18 @@ inline void deserialize(Stream& stream, T& t)
   Serializer<T>::read(stream, t);
 }
 
+// Circumvent bug https://github.com/ros/roscpp_core/issues/130 which manifests only on ARM GCC 9.3
+#if defined(__aarch64__) && __GNUC__ == 9 && __GNUC_MINOR__ == 3
+#define ROS_SERIALIZATION_GCC_9_3_DISABLE_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
+#else
+#define ROS_SERIALIZATION_GCC_9_3_DISABLE_VECTORIZE
+#endif
+  
 /**
  * \brief Determine the serialized length of an object
  */
 template<typename T>
-inline uint32_t serializationLength(const T& t)
+inline uint32_t ROS_SERIALIZATION_GCC_9_3_DISABLE_VECTORIZE serializationLength(const T& t)
 {
   return Serializer<T>::serializedLength(t);
 }


### PR DESCRIPTION
Closes #130.

@randoms Do you have a way to verify this fix helps?

I was able to reproduce the bug on arm64 Jetson with GCC 9.3.0. When I tested with 9.4.0 (which is now the default in Focal), the bug did not manifest. So I limited the fix to the only known combination triggering this issue - arm64 + GCC 9.3.