### PR TITLE
Use shorter wall sleeps in sim time for very short durations

### DIFF
--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -434,9 +434,11 @@ namespace ros
       }
 
       bool rc = false;
+      // This allows sim time to run up to 10x real-time even for very short sleep durations.
+      const uint32_t sleep_nsec = (sec != 0) ? 1000000 : (min)(1000000, nsec/10);
       while (!g_stopped && (Time::now() < end))
       {
-        ros_wallsleep(0, 1000000);
+        ros_wallsleep(0, sleep_nsec);
         rc = true;
 
         // If we started at time 0 wait for the first actual time to arrive before starting the timer on

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -435,7 +435,7 @@ namespace ros
 
       bool rc = false;
       // This allows sim time to run up to 10x real-time even for very short sleep durations.
-      const uint32_t sleep_nsec = (sec != 0) ? 1000000 : (min)(1000000, nsec/10);
+      const uint32_t sleep_nsec = (sec != 0) ? 1000000 : (std::min)(1000000, nsec/10);
       while (!g_stopped && (Time::now() < end))
       {
         ros_wallsleep(0, sleep_nsec);


### PR DESCRIPTION
Closes #133 .

I chose quite arbitrarily number 10 so that sim time running up to 10x real-time is supported even for short sleeps. This is a trade-off between performance and accuracy. If anybody has a reason to change this number, let me know.